### PR TITLE
fixpatch: Add option for adding Patch-Mainline tag

### DIFF
--- a/fixpatch.py
+++ b/fixpatch.py
@@ -47,6 +47,9 @@ def process_file(file, options):
         if options.reference:
             p.add_references(options.reference)
 
+        if options.mainline:
+            p.add_mainline(options.mainline)
+
         if options.dry_run:
             print p.message.as_string(unixfrom=False)
             return
@@ -90,6 +93,8 @@ if __name__ == "__main__":
     parser.add_option("-S", "--signed-off-by", action="store_true",
 		      default=False,
 		      help="Use Signed-off-by instead of Acked-by")
+    parser.add_option("-M", "--mainline", action="append", default=None,
+                      help="Add dummy Patch-mainline tag")
 
     (options, args) = parser.parse_args()
 

--- a/patch/Patch.py
+++ b/patch/Patch.py
@@ -129,6 +129,9 @@ class Patch:
 
         self.message.set_payload(text)
 
+    def add_mainline(self, tag):
+        self.message.add_header('Patch-mainline', string.join(tag))
+
     def from_email(self, msg):
         p = email.parser.Parser()
         self.message = p.parsestr(msg)


### PR DESCRIPTION
Add option for adding Patch-Mainline tag, even if it is not in mainline.
This is useful for patches that are picked up from mailing-lists and are
still accepted but not yet merged.

Signed-off-by: Johannes Thumshirn jthumshirn@suse.com
