### PR TITLE
Fix parsing of git remotes

### DIFF
--- a/patchtools/patchops.py
+++ b/patchtools/patchops.py
@@ -78,7 +78,7 @@ def get_diffstat(message):
 def get_git_repo_url(dir):
     command = f"(cd {dir}; git remote show origin -n)"
     output = run_command(command)
-    for line in output:
+    for line in output.split('\n'):
         m = re.search("URL:\s+(\S+)", line)
         if m:
             return m.group(1)


### PR DESCRIPTION
The output of `git remote show` must be explicitly split into
lines. Without this fix, `exportpatch` does not add the appropriate
`Patch-mainline` header.

Fixes: e48fae0c81644bea351a837f5894960eac08b4a1
Signed-off-by: Petr Tesarik <ptesarik@suse.com>