### PR TITLE
fixpatch: Fix import of PatchOps

### DIFF
--- a/scripts/fixpatch
+++ b/scripts/fixpatch
@@ -11,7 +11,7 @@ __author__ = 'Jeff Mahoney'
 
 
 from patchtools import PatchException
-from patchtools.patch import PatchOps, Patch
+from patchtools.patch import Patch
 from optparse import OptionParser
 import sys
 import os


### PR DESCRIPTION
The fixpatch script tries to import PatchOps but this class was previously dropped by commit 31625cd ("patchops: eliminate class PatchOps"). Fix the problem by removing the import because PatchOps is actually unused by the file.