### PR TITLE
patchtools: Improve detection of upstream commits

### DIFF
--- a/patchtools/patch.py
+++ b/patchtools/patch.py
@@ -143,7 +143,9 @@ class Patch:
     def is_mainline_commit(self):
         remote_name = self._get_commit_remote_name()
         remote_url = self._get_commit_remote_url(remote_name)
-        return remote_url in self.mainline_repo_list
+        if remote_url not in self.mainline_repo_list:
+            return run_command(f"cd {self.repo}; git branch -r --contains {self.commit}").find("origin/master") != -1
+        return True
 
     def from_email(self, msg):
         p = email.parser.Parser()
@@ -405,7 +407,7 @@ class Patch:
         body = ""
         chunk = ""
         text = ""
-        
+
         in_chunk = False
         in_patch = False
         lines = self.body().splitlines()


### PR DESCRIPTION
Sometimes it's possible for git to report that an upstream commit is reachable not directly via an upstream remote but through some 3rd party remote. For example upstream commit 0dcab41d3487 is reported as coming through intel-tdx remote rather than the upstream repo:

    $ git name-rev --refs "remotes/*" 0dcab41d3487
    0dcab41d3487 intel-tdx/guest-upstream~251^2~6

This leads to generating erroneous headers:

    $ exportpatch 0dcab41d3487 | head -n 5

    From: Tony Luck <tony.luck@intel.com>
    Date: Mon, 31 Jan 2022 15:01:07 -0800
    Subject: x86/cpu: Merge Intel and AMD ppin_init() functions
    Git-repo: git@github.com:intel/tdx.git
    Git-commit: 0dcab41d3487acadf64d0667398e032341bd9918

So fix this by not only relying on the output of git name-rev but also checking if the commit can be accessed via origin/master branch. With this change the output now is:

exportpatch 0dcab41d3487 | head -n 6
From: Tony Luck <tony.luck@intel.com>
Date: Mon, 31 Jan 2022 15:01:07 -0800
Subject: x86/cpu: Merge Intel and AMD ppin_init() functions Git-commit: 0dcab41d3487acadf64d0667398e032341bd9918 Patch-mainline: v5.18-rc1