### PR TITLE
patchtools: Add more mainline repos to the default config

### DIFF
--- a/patchtools/config.py
+++ b/patchtools/config.py
@@ -11,7 +11,11 @@ import re
 
 from patchtools.command import run_command
 
-MAINLINE_URLS = [ """git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-2.6.git""", """git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git""" ]
+MAINLINE_URLS = [ """git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-2.6.git""",
+                  """git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git""",
+                  """https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git""",
+                  """https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux.git"""
+                ]
 
 def get_git_repo_url(gitdir):
     command = f"(cd {gitdir}; git remote show origin -n)"


### PR DESCRIPTION
Add an https:// variant of Linus's git.k.o tree, plus an https:// of Google's mirror.
This fixes bad exportpatch output when the local mainline repo has any of those as a mirror. 