### PR TITLE
Fix fixpatch extract on Python 3.6

### DIFF
--- a/patchtools/command.py
+++ b/patchtools/command.py
@@ -1,8 +1,8 @@
 import subprocess
 import sys
 
-def run_command(command, stdin=None, input=None, stdout=subprocess.PIPE):
+def run_command(command, input=None, stdout=subprocess.PIPE):
     proc = subprocess.run(command, shell=True, encoding='utf-8',
-                          stdin=stdin, input=input, stdout=stdout,
+                          input=input, stdout=stdout,
                           stderr=open("/dev/null", "w"))
     return proc.stdout


### PR DESCRIPTION
the subprocess package on Python 3.6 seems to have an issue with calling subprocess.run(), if specifying both the 'stdin' argument and the 'input' argument, when and 'input' value gets passed in, even though the 'stdin' argument is set to None. This throws an error like (note the last line):

sh> exportpatch -x drivers/scsi/st  8db816c6f176321e42254badd5c1a8df8bfcfdb4 Traceback (most recent call last):
  File "/usr/bin/exportpatch", line 133, in <module>
    export_patch(commit, options, prefix, suffix)
  File "/usr/bin/exportpatch", line 37, in export_patch
    p.filter(options.extract)
  File "/usr/lib/python3.6/site-packages/patchtools/patch.py", line 469, in filter
    self.update_diffstat()
  File "/usr/lib/python3.6/site-packages/patchtools/patch.py", line 90, in update_diffstat
    self.add_diffstat()
  File "/usr/lib/python3.6/site-packages/patchtools/patch.py", line 54, in add_diffstat
    diffstat = patchops.get_diffstat(self.body())
  File "/usr/lib/python3.6/site-packages/patchtools/patchops.py", line 75, in get_diffstat
    return run_command("diffstat -p1", input=message)
  File "/usr/lib/python3.6/site-packages/patchtools/command.py", line 7, in run_command
    stderr=open("/dev/null", "w"))
  File "/usr/lib64/python3.6/subprocess.py", line 420, in run
    raise ValueError('stdin and input arguments may not both be used.')
ValueError: stdin and input arguments may not both be used.

To fix this, remove the 'stdin' argument to run_command() and to run(), since we never use it.