### PR TITLE
Add bug fixes and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,14 @@ sdist
 develop-eggs
 .installed.cfg
 
+# from virtual environment
+create
+delete
+*venv
+
+# from vim
+.*.swp
+
 # Installer logs
 pip-log.txt
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,15 @@
-2011?   Jeff Mahoney    Created
+Created by:
+===========
+    Jeff Mahoney <jeffm@suse.com>
 
-2012    Lee Duncan      Updated to be more modular.
+Contributors:
+=============
+    Lee Duncan <lduncan@suse.com>
+    Borislav Petkov <bp@suse.de>
+    Johannes Thumshirn <jthumshirn@suse.de>
+    Michal Koutný <mkoutny@suse.com>
+    Nikolay Borisov <nik.borisov@suse.com>
+    Pedro Falcato <pfalcato@suse.de>
+    Petr Pavlu <petr.pavlu@suse.com>
+    Petr Tesarik <ptesarik@suse.com>
+    Tony Jones <tonyj@suse.de>

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/patchtools/exportpatch.py
+++ b/patchtools/exportpatch.py
@@ -61,7 +61,7 @@ def export_patch(commit, options, prefix, suffix):
         else:
             print(p.message.as_string(False))
         return 0
-    
+
     print("Couldn't locate commit \"%s\"; Skipping." % commit, file=sys.stderr)
     return 1
 

--- a/patchtools/fixpatch.py
+++ b/patchtools/fixpatch.py
@@ -1,12 +1,11 @@
-#!/usr/bin/python3
-# vim: sw=4 ts=4 et si:
-"""
+"""Fix an existing patch with the proper tags.
+
 Take an existing patch and add the appropriate tags, drawing from known
 repositories to discover the origin. Also, renames the patch using the
 subject found in the patch itself.
 """
 
-__revision__ = 'Revision: 2.0'
+__revision__ = 'Revision: 2.5'
 __author__ = 'Jeff Mahoney'
 
 
@@ -16,7 +15,9 @@ from optparse import OptionParser
 import sys
 import os
 
+
 def process_file(pathname, options):
+    """Fix one patchfile. Return 0 for success."""
     try:
         p = Patch()
         f = open(pathname, "r")
@@ -79,7 +80,8 @@ def process_file(pathname, options):
     except PatchException as e:
         print(e, file=sys.stderr)
 
-if __name__ == "__main__":
+def main():
+    """The main entry point for this module. Return 0 for success."""
     parser = OptionParser(version='%prog ' + __revision__)
     parser.add_option("-n", "--dry-run", action="store_true", default=False,
                       help="Output results to stdout but don't commit change")
@@ -112,9 +114,11 @@ if __name__ == "__main__":
 
     if not args:
         parser.error("Must supply patch filename(s)")
-        sys.exit(1)
+        return 1
 
     for pathname in args:
         process_file(pathname, options)
 
-    sys.exit(0)
+    return 0
+
+# vim: sw=4 ts=4 et si:

--- a/patchtools/patch.py
+++ b/patchtools/patch.py
@@ -130,7 +130,11 @@ class Patch:
         self.message.set_payload(text)
 
     def add_mainline(self, tag):
-        self.message.add_header('Patch-mainline', ' '.join(tag))
+        """Add or create a 'Patch-mainline' header, with 'tag'."""
+        if 'Patch-mainline' in self.message:
+            self.message.replace_header('Patch-mainline', ' '.join(tag))
+        else:
+            self.message.add_header('Patch-mainline', ' '.join(tag))
 
     def from_email(self, msg):
         p = email.parser.Parser()

--- a/patchtools/patchops.py
+++ b/patchtools/patchops.py
@@ -117,9 +117,9 @@ def safe_filename(name, keep_non_patch_brackets = True):
     # to remove noise from the subject line.
     # keep_non_patch_brackets=True is the equivalent of git am -b
     if keep_non_patch_brackets:
-        name = re.sub(r'(([Rr][Ee]:|\[PATCH[^]]*\])[ \t]*)*', '', name, 1)
+        name = re.sub(r'(([Rr][Ee]:|\[PATCH[^]]*\])[ \t]*)*', '', name, count=1)
     else:
-        name = re.sub(r'(([Rr][Ee]:|\[[^]]*\])[ \t]*)*', '', name, 1)
+        name = re.sub(r'(([Rr][Ee]:|\[[^]]*\])[ \t]*)*', '', name, count=1)
 
     # This mimics the filters that git-format-patch applies prior to adding
     # prefixes or suffixes.

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,52 @@
-#!/usr/bin/python3
-# vim: sw=4 ts=4 et si:
-"""
-Setup file for installation
+"""Setup file for installation.
+
+Not used for Python version >= 3.11
+
+We magically create front-ends for our scripts,
+and we cleanup up after ourselves if setup is given
+the 'clean' command.
 """
 
 import os
-import sys
 import shutil
-import site
-from setuptools import setup, Command
+
+from setuptools import Command, setup
+
+
+# our scripts -- we will create front ends for these
+SCRIPT_MODULES = ['exportpatch', 'fixpatch']
+
+
+class CleanCommand(Command):
+    """Clean up after a build"""
+
+    description = 'Clean up after ourselves'
+    user_options = []
+
+    def initialize_options(self):
+        self.cwd = None
+
+    def finalize_options(self):
+        self.cwd = os.getcwd()
+
+    def run(self):
+        if os.getcwd() != self.cwd:
+            raise Exception(f'Must be in package root: {self.cwd}')
+        print('Removing "build" subdirectory, and everything under it')
+        shutil.rmtree('./build', ignore_errors=True)
+        print('Removing egg-info files, if any')
+        shutil.rmtree('./patchtools.egg-info', ignore_errors=True)
+
 
 setup(
-    author="Jeff Mahoney",
-    author_email="jeffm@suse.com",
-    name="patchtools",
-    packages=["patchtools"],
-    scripts=["scripts/exportpatch", "scripts/fixpatch"],
-    version="2.5")
+    cmdclass={'clean': CleanCommand},
+    author='Jeff Mahoney',
+    author_email='jeffm@suse.com',
+    name='patchtools',
+    packages=['patchtools'],
+    entry_points={
+        'console_scripts': [f'{m} = patchtools.{m}:main' for m in SCRIPT_MODULES],
+        },
+    version='2.5')
+
+# vim: sw=4 ts=4 et si:

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -1,0 +1,451 @@
+# Testing for patchtools, using pyunit
+
+## Version of Python
+
+Currently, this report supports Python 3.6, 3.11, and 3.13,
+but testing has been done on Python 3.6, since that's the
+oldest version currently supported.
+
+## What to test -- Which Scripts do we actually test?
+
+These unit tests execute code in the source tree by running fixpatch:main
+and exportpatch:main directly.
+
+This allows the tests to be run on the source base, not the installed
+(if any) package, and it allows code coverage to be measured when
+testing.
+
+## How to test
+
+The pyunit unit testing framework is used, aka unittest.
+
+The tests all live in the "test/" subdirectory, with a "data/"
+subdirectory under it, where known good patchfiles exist,
+
+For configuration, the tests create their own configuration file,
+with the bogus user name and email address, so that the tests can
+be user-independant. The tests also requires a valid Linux
+git repository whos pathname is passed to the tests via the
+"LINUX\_GIT" environment variable. This repository should be
+up to date, and point to a valid Linux upstream repo, such as:
+
+    git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+
+
+## Things to test
+
+### exportpatch (testing at 100% now)
+
+#### error conditions
+
+* bogus commit supplied (does not match anything)
+* no commit supplied
+* try to supply "HEAD" or "^" (should fail)
+* incorrect patch config file (points to nothing?)
+* no patch config file?
+* try to write with no write permission in dir
+* invalid directory supplied to write patch
+* specify out-of-range starting number for a numbered patch
+* trying to write a patch file when one already exists without --force (should get funky name)
+
+* test with various (or missing) config file for what RFEPOs to search
+
+
+#### normal ops
+
+Export a simple commit, just one file, just one hunk:
+
+* export to a dir/file, using defaults
+  repeat with a suffix
+* export to a dir/file, using numeric values,
+  repeat with non-default starting number
+  repeat with non-default width
+* export to a dir/file, using 'force' to overwrite
+  repeat without force set
+* export to stdout
+* export to current dir
+* export to dir/file, testing single reference
+* export to dir/file, with double reference
+* export to dir/file, testing single reference
+* export to dir/file, using 'signed-off-by'
+* export two commits, using defauls
+
+
+Extract testing:
+
+* export to file, extract whole (single) file
+* repeat with two files
+* repeat with specified file not in patch w/one file
+* repeat with specified file not in patch w/two files
+* repeat with one of two files in patch specified
+* repeat with multiple files and multiple 'x' options
+
+Exclude testing:
+
+* exclude only file in one-file commit
+* exclude all files in multi-file commit with a pattern
+* exclude all files in multi-file commit with repeated options
+* exclude nothing (bogus path) from one-file commit
+* exclude nothing (bogus path) from multi-file commit
+* exclude two files from multi-file commit
+
+
+#### error ops
+
+Test bogus params, such as:
+
+* bogus commit                                           
+* no commit                                              
+* bad arguments (short and long)                         
+* num-width with no value                                
+* illegal values for num-width? (range is 1 to 4)        
+  this is currently difficult, since out-of-range
+  vlaues are silently ignored. We should test by checking
+  the actual width of the output number string in a patch?
+* test first-number                                      
+  with no commit and no number
+  with bogus number and and bogus commit
+  with bogus number and valid commit
+  with number out of range (too small & too large)
+* REFERENCE with no value                                
+* export to a dir with errors                            
+  export to dir but dirname not supplied
+  dir does not exist
+  dir is read only
+
+
+### fixpatch
+
+#### normal ops
+
+* fix a patch -- defaults
+  ensure it adds acked-by
+  ensure it adds diffstat
+  ensure it renames?
+  (duplicate?)
+
+Test params:
+
+* test no-rename
+* test with rename
+* test adding a suffix
+* test dry-run (should do nothing)
+* test rename collision, wiht force
+* test rename collision, without force
+* test name-only
+* test name-only with suffix
+* test no-ack (-N)
+* test no-diffstat (-D)
+* test header-only (no-ack and no-diffstat) (-H)
+* test update-only (no-ack, no-diffstat, no-rename) (-U)
+* test setting 1st reference (-F <ref>)
+* test setting 2nd reference (-F <ref>)
+* test with multiple references
+* test header-only and a reference (-H -F <ref>)
+* test signed-off-by (vs normal acked-by) (-S)
+* test setting single dummy mainline tag (-M <mainline>)
+* test setting two dummy mainline tags (-M <mainline> twice)
+* test adding reference that already exist
+* test with Signed-off-by already present
+
+#### error conditions
+
+* no patch filename specified
+* pathname specified does not exist
+* no rename but source patch is not writable
+* patch directory not writable
+* empty patch (so no Subject line)
+* patch with just Subject, which has:
+  no seperator
+  no commit
+  no from
+  first signed-off-by
+* patch with just Subject and ref
+* patch with just Subject and signed-off-by already there
+
+-- DONE TO HERE --
+
+* patch with valid patch that has bogus Patch-mainline              -- XXX to do
+* test with having 'Git-commit' already in patch                    -- XXX soon
+
+* patch specified doesn't exist upstream? (i.e. a fake patch)
+  (not sure what will happen here)
+
+* patch after rename exists but is not writable
+  (never mind -- it won't write over an existing patch filename)
+
+
+### generic stuff
+
+#### config.cfg
+
+Right now the only generic stuff is reading the config file,
+because that's done in the init file of the patchtools module.
+
+It _should_ be read later, IMHO, which would make easier?
+
+How do we test it now, with the config file being read way
+before any test case is read?
+
+An even better fix would be to make the config setup externally
+available, so it could be tested separately.
+
+### patch.cfg
+
+* Supply patch with 'X-Git-Url:' header set to a non-URL string
+* Supply patch with no Subject line
+* Supply a completely empty body (using fixpatch?)
+
+
+## How to Test
+
+To run these tests, using the python unittest module. For
+example, from the source directory, you can run:
+
+    zsh> python3 -m unittest -v test
+
+If you like a nicer interface, you can use "pytest", as
+a unit, or from the command line, i.e. this:
+
+    zsh> python3 -m pytest -v test
+
+Note that, in general, wherever you see "unittest", or "pytest",
+you can generally use either.
+
+If you prefer the command line interface of pytest, you can run:
+
+    zsh> pytest -v test
+
+This will run all the tests in the "test" class, which
+are in the "test" subdirectory. The "-v" adds more verbosity.
+
+To run a single test, you could use, for example:
+
+    zsh> pytest -v test.test_exportpatch.TestExportpatchNormalFunctionality.test_to_stdout_defaults
+
+## Testing Code Coverage
+
+If you would like to test the code coverage of these tests, you can install
+the "pytest-cov" package, then run:
+
+    zsh> coverage run --source=patchtools -m pytest -v test
+
+Then, to get the coverage report:
+
+    zsh> coverage report
+
+
+# Test Structure
+
+The tests are in files named "test_exportpatch.py" and "test_fixpatch.py",
+and use the unittest.
+
+There are multiple test classes in each test file. Each class groups together
+multiple test cases that focus on a common area. Each self test is named along
+the lines of "test_SOMETHING()".
+
+The test framework finds the tests and runs them for you, as long as the naming
+convention is followed.
+
+# Known Bugs
+
+For lack of a better place to track them, here's hopefully-current list
+of known bugs, discovered during test creation or testing:
+
+## Usage message of fixpatch
+
+It says "-s"/"--suffix" is useful with "-w", but there is not "-w" in
+fixpatch, so this seems like a cut-n-paste error.
+
+This is a help message bug, not a functional bug.
+
+### status: not fixed
+
+## fixpatch on a non-existant file
+
+It prints a stack dump. But exporpatch is much nicer if if you hit a
+similar case, printing out a nice message. This is really more of an
+enhancement than a bug fix.
+
+### status: not fixed
+
+## exporting a commit with a UTF-8 string seems to get strange chars
+
+check out this commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+
+This may or may not be a bug? It leaves the "from" name kind
+of funky, e.g.:
+
+    zsh> exportpatch  8db816c6f176321e42254badd5c1a8df8bfcfdb4 | head -1
+    From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+
+but ''git show'' on the same commit has different output:
+
+    zsh git show 8db816c6f176321e42254badd5c1a8df8bfcfdb4 | head -2
+    commit 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+    Author: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+
+So should be rendering utf charaters better?
+
+Not a new issue. Might actually be a "feature"?
+
+### status: not fixed
+
+## exportpatch parser uses parser.error()
+
+This function, from optparse.OptionParser, prints an
+error message then exits, but we have (had?):
+
+    ...
+    ...
+    parser.error('some message')
+    return 1
+
+This also makes the unit test fail for parser errors.
+
+### status: fix in place
+
+## OptionParser likes to call sys.exit()
+
+duplicate of above issue?
+
+when the option parser gets an error, like an option
+that should have a value associated with it but does not,
+it calls "parser.error()", which ends up calling sys.exit().
+
+This makes testing hard, so catch such errors.
+
+### status: fix in place
+
+## exportpatch num_width can be ignored
+
+If the "-N width" value is less than 1 or more than 4,
+it is silently ignored. There should at least be a
+warning message, if not an error message?
+
+### status: not fixed
+
+## exportpatch treats first-number and and num-width differently
+
+It tells the option parser that num-width is an int, but it
+fails to do so for first-number, so we have to manually parse
+first-number ourselves, making the error messages for both
+have different paths and print different error messages.
+
+### status: not fixed
+
+## exportpatch stack dumps when writing to non-existant directory
+
+This exception could be caught, and a nicer message printed.
+
+### status: not fixed
+
+## exportpatch nit: when writing to a dir that doesn't exist, print patch filename?
+
+When we print to a dir that doesn't exist, we print the patch pathname,
+as usual, then try to open it. If the open fails, we print an error
+and exit. But why print the patch filename in such a case?
+
+### status: not fixed
+
+## the config file is read too early in the python code
+
+The configuration file is found and read when the module is
+loaded, from \_\_init\_\_.py, even though we may not be calling
+the main exportpatch or fixpatch code yet.
+
+It shouldn't be read until the commands are called, IMHO. The
+current method makes testing a little heard, because we have
+to create a config file before we even import the module.
+
+### status: not fixed
+
+## fixpatch help usage is wrong
+
+It doesn't mention that you need to supply one or more patches
+to be fixed because it uses the default help usage message.
+
+### status: fix in place (simple)
+
+## fixpatch no-diffstat doesn't remove existing diffstat
+
+This option to fixpatch does not add a diffstat, but it
+will not remove one, either. Probably not a bug.
+
+### status: fixed: changed wording
+
+## fixpatch does not limit patch filename length during rename
+
+I haven't tested with non-suffix, where the patch filename is
+just from the subject line, but when adding a suffix, it
+does not limit the patch filename length to 64, as does
+exportpatch.
+
+### status: not fixed (may be a "feature"? does it matter?)
+
+## fixpatch useless debug statement
+
+It appears that "-d" (debug) isn't available for fixpatch,
+and there's a debug statement that can never be called
+in Patch(), which can never show up from fixpatch
+
+### status: not fixed
+
+## fixpatch setting dummy patch-mainline gives a duplicate
+
+When you set this, you get two "Patch-mainline:" headers.
+And this is on an initial patch being fixed that has no
+such header, so fixpatch is adding two of them
+
+### status: fixed
+
+## fixpatch pukes stack dummp when supplied patch filename doesn't exist
+
+### status: fix in place (simple)
+
+
+## fixpatch didn't return error to CLI
+
+The code never plumbed a return value.
+
+### status: fix in place
+
+## fixpatch called sys.exit() for CLI option errors
+
+Like exportpatch, it used "parser.error()", which
+ends up calling sys.exit().
+
+### status: fix in place
+
+## fixpatch no rename to a read-only dumps stack
+
+Should be cleaner.
+
+### status: simple fix in place
+
+## fixpatch if patch filename is readonly it still prints it out
+
+Don't need to see the patchname when it isn't being generated!
+
+### status: simple fix in place
+
+
+
+
+
+
+# infrastructure bugs (common to exportpatch and fixpatch)
+
+## in patch.py: "switched" seems unused?
+
+## in patch.py: add_signature() signed-off-by not used
+
+## in patch.py: update_refs() method never used
+
+## in patch.py, the Patch() repo argument is never ever used
+
+
+# in generral
+
+## replace deprecated (since 2.7!) optparse with argparse
+

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,16 @@
+"""The 'test' class for patchtools."""
+
+from .test_exportpatch import TestExportpatchExclude, TestExportpatchExtract, TestExportpatchNormalFunctionality
+from .test_fixpatch import TestFixpatchErrorCases, TestFixpatchNormalFunctionality
+from .test_patch import TestPatchModuleNormalFunctionality
+
+__all__ = [
+    'TestExportpatchExclude',
+    'TestExportpatchExtract',
+    'TestExportpatchNormalFunctionality',
+    'TestFixpatchErrorCases',
+    'TestFixpatchNormalFunctionality',
+    'TestPatchModuleNormalFunctionality',
+    ]
+
+# vim: sw=4 ts=4 et si:

--- a/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.2f_of_2
+++ b/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.2f_of_2
@@ -1,0 +1,108 @@
+From: Chaohai Chen <wdhh6@aliyun.com>
+Date: Sat, 6 Dec 2025 14:06:16 +0800
+Subject: scsi: libsas: Add rollback handling when an error occurs
+Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41
+Patch-mainline: v6.19-rc1
+
+In sas_register_phys(), if an error is triggered in the loop process, we
+need to roll back the resources that have already been requested.
+
+Add sas_unregister_phys() when an error occurs in sas_register_ha().
+
+[mkp: a few coding style tweaks and address John's comment]
+
+Signed-off-by: Chaohai Chen <wdhh6@aliyun.com>
+Reviewed-by: John Garry <john.g.garry@oracle.com>
+Link: https://patch.msgid.link/20251206060616.69216-1-wdhh6@aliyun.com
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+
+ drivers/scsi/libsas/sas_init.c     |    1 +
+ drivers/scsi/libsas/sas_internal.h |    1 +
+ drivers/scsi/libsas/sas_phy.c      |   33 ++++++++++++++++++++++++++++++---
+ 3 files changed, 32 insertions(+), 3 deletions(-)
+
+--- a/drivers/scsi/libsas/sas_init.c
++++ b/drivers/scsi/libsas/sas_init.c
+@@ -141,6 +141,7 @@ int sas_register_ha(struct sas_ha_struct *sas_ha)
+ Undo_ports:
+ 	sas_unregister_ports(sas_ha);
+ Undo_phys:
++	sas_unregister_phys(sas_ha);
+ 
+ 	return error;
+ }
+
+--- a/drivers/scsi/libsas/sas_internal.h
++++ b/drivers/scsi/libsas/sas_internal.h
+@@ -54,6 +54,7 @@ void sas_unregister_dev(struct asd_sas_port *port, struct domain_device *dev);
+ void sas_scsi_recover_host(struct Scsi_Host *shost);
+ 
+ int  sas_register_phys(struct sas_ha_struct *sas_ha);
++void sas_unregister_phys(struct sas_ha_struct *sas_ha);
+ 
+ struct asd_sas_event *sas_alloc_event(struct asd_sas_phy *phy, gfp_t gfp_flags);
+ void sas_free_event(struct asd_sas_event *event);
+
+--- a/drivers/scsi/libsas/sas_phy.c
++++ b/drivers/scsi/libsas/sas_phy.c
+@@ -116,6 +116,7 @@ static void sas_phye_shutdown(struct work_struct *work)
+ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ {
+ 	int i;
++	int err;
+ 
+ 	/* Now register the phys. */
+ 	for (i = 0; i < sas_ha->num_phys; i++) {
+@@ -132,8 +133,10 @@ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ 		phy->frame_rcvd_size = 0;
+ 
+ 		phy->phy = sas_phy_alloc(&sas_ha->shost->shost_gendev, i);
+-		if (!phy->phy)
+-			return -ENOMEM;
++		if (!phy->phy) {
++			err = -ENOMEM;
++			goto rollback;
++		}
+ 
+ 		phy->phy->identify.initiator_port_protocols =
+ 			phy->iproto;
+@@ -146,10 +149,34 @@ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ 		phy->phy->maximum_linkrate = SAS_LINK_RATE_UNKNOWN;
+ 		phy->phy->negotiated_linkrate = SAS_LINK_RATE_UNKNOWN;
+ 
+-		sas_phy_add(phy->phy);
++		err = sas_phy_add(phy->phy);
++		if (err) {
++			sas_phy_free(phy->phy);
++			goto rollback;
++		}
+ 	}
+ 
+ 	return 0;
++rollback:
++	for (i-- ; i >= 0 ; i--) {
++		struct asd_sas_phy *phy = sas_ha->sas_phy[i];
++
++		sas_phy_delete(phy->phy);
++		sas_phy_free(phy->phy);
++	}
++	return err;
++}
++
++void sas_unregister_phys(struct sas_ha_struct *sas_ha)
++{
++	int i;
++
++	for (i = 0 ; i < sas_ha->num_phys ; i++) {
++		struct asd_sas_phy *phy = sas_ha->sas_phy[i];
++
++		sas_phy_delete(phy->phy);
++		sas_phy_free(phy->phy);
++	}
+ }
+ 
+ const work_func_t sas_phy_event_fns[PHY_NUM_EVENTS] = {
+
+

--- a/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.excluded_first_and_last
+++ b/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.excluded_first_and_last
@@ -1,0 +1,37 @@
+From: Chaohai Chen <wdhh6@aliyun.com>
+Date: Sat, 6 Dec 2025 14:06:16 +0800
+Subject: scsi: libsas: Add rollback handling when an error occurs
+Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41
+ (partial)
+Patch-mainline: v6.19-rc1
+Patch-filtered: !drivers/scsi/libsas/sas_init.c !drivers/scsi/libsas/sas_phy.c
+
+In sas_register_phys(), if an error is triggered in the loop process, we
+need to roll back the resources that have already been requested.
+
+Add sas_unregister_phys() when an error occurs in sas_register_ha().
+
+[mkp: a few coding style tweaks and address John's comment]
+
+Signed-off-by: Chaohai Chen <wdhh6@aliyun.com>
+Reviewed-by: John Garry <john.g.garry@oracle.com>
+Link: https://patch.msgid.link/20251206060616.69216-1-wdhh6@aliyun.com
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+
+ drivers/scsi/libsas/sas_internal.h |    1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/scsi/libsas/sas_internal.h
++++ b/drivers/scsi/libsas/sas_internal.h
+@@ -54,6 +54,7 @@ void sas_unregister_dev(struct asd_sas_port *port, struct domain_device *dev);
+ void sas_scsi_recover_host(struct Scsi_Host *shost);
+ 
+ int  sas_register_phys(struct sas_ha_struct *sas_ha);
++void sas_unregister_phys(struct sas_ha_struct *sas_ha);
+ 
+ struct asd_sas_event *sas_alloc_event(struct asd_sas_phy *phy, gfp_t gfp_flags);
+ void sas_free_event(struct asd_sas_event *event);
+
+

--- a/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.extracted
+++ b/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.extracted
@@ -1,0 +1,108 @@
+From: Chaohai Chen <wdhh6@aliyun.com>
+Date: Sat, 6 Dec 2025 14:06:16 +0800
+Subject: scsi: libsas: Add rollback handling when an error occurs
+Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41
+Patch-mainline: v6.19-rc1
+
+In sas_register_phys(), if an error is triggered in the loop process, we
+need to roll back the resources that have already been requested.
+
+Add sas_unregister_phys() when an error occurs in sas_register_ha().
+
+[mkp: a few coding style tweaks and address John's comment]
+
+Signed-off-by: Chaohai Chen <wdhh6@aliyun.com>
+Reviewed-by: John Garry <john.g.garry@oracle.com>
+Link: https://patch.msgid.link/20251206060616.69216-1-wdhh6@aliyun.com
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+
+ drivers/scsi/libsas/sas_init.c     |    1 +
+ drivers/scsi/libsas/sas_internal.h |    1 +
+ drivers/scsi/libsas/sas_phy.c      |   33 ++++++++++++++++++++++++++++++---
+ 3 files changed, 32 insertions(+), 3 deletions(-)
+
+--- a/drivers/scsi/libsas/sas_init.c
++++ b/drivers/scsi/libsas/sas_init.c
+@@ -141,6 +141,7 @@ int sas_register_ha(struct sas_ha_struct *sas_ha)
+ Undo_ports:
+ 	sas_unregister_ports(sas_ha);
+ Undo_phys:
++	sas_unregister_phys(sas_ha);
+ 
+ 	return error;
+ }
+
+--- a/drivers/scsi/libsas/sas_internal.h
++++ b/drivers/scsi/libsas/sas_internal.h
+@@ -54,6 +54,7 @@ void sas_unregister_dev(struct asd_sas_port *port, struct domain_device *dev);
+ void sas_scsi_recover_host(struct Scsi_Host *shost);
+ 
+ int  sas_register_phys(struct sas_ha_struct *sas_ha);
++void sas_unregister_phys(struct sas_ha_struct *sas_ha);
+ 
+ struct asd_sas_event *sas_alloc_event(struct asd_sas_phy *phy, gfp_t gfp_flags);
+ void sas_free_event(struct asd_sas_event *event);
+
+--- a/drivers/scsi/libsas/sas_phy.c
++++ b/drivers/scsi/libsas/sas_phy.c
+@@ -116,6 +116,7 @@ static void sas_phye_shutdown(struct work_struct *work)
+ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ {
+ 	int i;
++	int err;
+ 
+ 	/* Now register the phys. */
+ 	for (i = 0; i < sas_ha->num_phys; i++) {
+@@ -132,8 +133,10 @@ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ 		phy->frame_rcvd_size = 0;
+ 
+ 		phy->phy = sas_phy_alloc(&sas_ha->shost->shost_gendev, i);
+-		if (!phy->phy)
+-			return -ENOMEM;
++		if (!phy->phy) {
++			err = -ENOMEM;
++			goto rollback;
++		}
+ 
+ 		phy->phy->identify.initiator_port_protocols =
+ 			phy->iproto;
+@@ -146,10 +149,34 @@ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ 		phy->phy->maximum_linkrate = SAS_LINK_RATE_UNKNOWN;
+ 		phy->phy->negotiated_linkrate = SAS_LINK_RATE_UNKNOWN;
+ 
+-		sas_phy_add(phy->phy);
++		err = sas_phy_add(phy->phy);
++		if (err) {
++			sas_phy_free(phy->phy);
++			goto rollback;
++		}
+ 	}
+ 
+ 	return 0;
++rollback:
++	for (i-- ; i >= 0 ; i--) {
++		struct asd_sas_phy *phy = sas_ha->sas_phy[i];
++
++		sas_phy_delete(phy->phy);
++		sas_phy_free(phy->phy);
++	}
++	return err;
++}
++
++void sas_unregister_phys(struct sas_ha_struct *sas_ha)
++{
++	int i;
++
++	for (i = 0 ; i < sas_ha->num_phys ; i++) {
++		struct asd_sas_phy *phy = sas_ha->sas_phy[i];
++
++		sas_phy_delete(phy->phy);
++		sas_phy_free(phy->phy);
++	}
+ }
+ 
+ const work_func_t sas_phy_event_fns[PHY_NUM_EVENTS] = {
+
+

--- a/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.extracted_file2_of_3
+++ b/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.extracted_file2_of_3
@@ -1,0 +1,37 @@
+From: Chaohai Chen <wdhh6@aliyun.com>
+Date: Sat, 6 Dec 2025 14:06:16 +0800
+Subject: scsi: libsas: Add rollback handling when an error occurs
+Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41
+ (partial)
+Patch-mainline: v6.19-rc1
+Patch-filtered: drivers/scsi/libsas/sas_internal.h
+
+In sas_register_phys(), if an error is triggered in the loop process, we
+need to roll back the resources that have already been requested.
+
+Add sas_unregister_phys() when an error occurs in sas_register_ha().
+
+[mkp: a few coding style tweaks and address John's comment]
+
+Signed-off-by: Chaohai Chen <wdhh6@aliyun.com>
+Reviewed-by: John Garry <john.g.garry@oracle.com>
+Link: https://patch.msgid.link/20251206060616.69216-1-wdhh6@aliyun.com
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+
+ drivers/scsi/libsas/sas_internal.h |    1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/scsi/libsas/sas_internal.h
++++ b/drivers/scsi/libsas/sas_internal.h
+@@ -54,6 +54,7 @@ void sas_unregister_dev(struct asd_sas_port *port, struct domain_device *dev);
+ void sas_scsi_recover_host(struct Scsi_Host *shost);
+ 
+ int  sas_register_phys(struct sas_ha_struct *sas_ha);
++void sas_unregister_phys(struct sas_ha_struct *sas_ha);
+ 
+ struct asd_sas_event *sas_alloc_event(struct asd_sas_phy *phy, gfp_t gfp_flags);
+ void sas_free_event(struct asd_sas_event *event);
+
+

--- a/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.known_good
+++ b/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.known_good
@@ -1,0 +1,110 @@
+From: Chaohai Chen <wdhh6@aliyun.com>
+Date: Sat, 6 Dec 2025 14:06:16 +0800
+Subject: scsi: libsas: Add rollback handling when an error occurs
+Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41
+Patch-mainline: v6.19-rc1
+
+In sas_register_phys(), if an error is triggered in the loop process, we
+need to roll back the resources that have already been requested.
+
+Add sas_unregister_phys() when an error occurs in sas_register_ha().
+
+[mkp: a few coding style tweaks and address John's comment]
+
+Signed-off-by: Chaohai Chen <wdhh6@aliyun.com>
+Reviewed-by: John Garry <john.g.garry@oracle.com>
+Link: https://patch.msgid.link/20251206060616.69216-1-wdhh6@aliyun.com
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/libsas/sas_init.c     |  1 +
+ drivers/scsi/libsas/sas_internal.h |  1 +
+ drivers/scsi/libsas/sas_phy.c      | 33 ++++++++++++++++++++++++++++++---
+ 3 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/scsi/libsas/sas_init.c b/drivers/scsi/libsas/sas_init.c
+index 8566bb1208a0..6b15ad1bcada 100644
+--- a/drivers/scsi/libsas/sas_init.c
++++ b/drivers/scsi/libsas/sas_init.c
+@@ -141,6 +141,7 @@ int sas_register_ha(struct sas_ha_struct *sas_ha)
+ Undo_ports:
+ 	sas_unregister_ports(sas_ha);
+ Undo_phys:
++	sas_unregister_phys(sas_ha);
+ 
+ 	return error;
+ }
+diff --git a/drivers/scsi/libsas/sas_internal.h b/drivers/scsi/libsas/sas_internal.h
+index da5408c701cd..d104c87f04f5 100644
+--- a/drivers/scsi/libsas/sas_internal.h
++++ b/drivers/scsi/libsas/sas_internal.h
+@@ -54,6 +54,7 @@ void sas_unregister_dev(struct asd_sas_port *port, struct domain_device *dev);
+ void sas_scsi_recover_host(struct Scsi_Host *shost);
+ 
+ int  sas_register_phys(struct sas_ha_struct *sas_ha);
++void sas_unregister_phys(struct sas_ha_struct *sas_ha);
+ 
+ struct asd_sas_event *sas_alloc_event(struct asd_sas_phy *phy, gfp_t gfp_flags);
+ void sas_free_event(struct asd_sas_event *event);
+diff --git a/drivers/scsi/libsas/sas_phy.c b/drivers/scsi/libsas/sas_phy.c
+index 635835c28ecd..58f08dc2c187 100644
+--- a/drivers/scsi/libsas/sas_phy.c
++++ b/drivers/scsi/libsas/sas_phy.c
+@@ -116,6 +116,7 @@ static void sas_phye_shutdown(struct work_struct *work)
+ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ {
+ 	int i;
++	int err;
+ 
+ 	/* Now register the phys. */
+ 	for (i = 0; i < sas_ha->num_phys; i++) {
+@@ -132,8 +133,10 @@ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ 		phy->frame_rcvd_size = 0;
+ 
+ 		phy->phy = sas_phy_alloc(&sas_ha->shost->shost_gendev, i);
+-		if (!phy->phy)
+-			return -ENOMEM;
++		if (!phy->phy) {
++			err = -ENOMEM;
++			goto rollback;
++		}
+ 
+ 		phy->phy->identify.initiator_port_protocols =
+ 			phy->iproto;
+@@ -146,10 +149,34 @@ int sas_register_phys(struct sas_ha_struct *sas_ha)
+ 		phy->phy->maximum_linkrate = SAS_LINK_RATE_UNKNOWN;
+ 		phy->phy->negotiated_linkrate = SAS_LINK_RATE_UNKNOWN;
+ 
+-		sas_phy_add(phy->phy);
++		err = sas_phy_add(phy->phy);
++		if (err) {
++			sas_phy_free(phy->phy);
++			goto rollback;
++		}
+ 	}
+ 
+ 	return 0;
++rollback:
++	for (i-- ; i >= 0 ; i--) {
++		struct asd_sas_phy *phy = sas_ha->sas_phy[i];
++
++		sas_phy_delete(phy->phy);
++		sas_phy_free(phy->phy);
++	}
++	return err;
++}
++
++void sas_unregister_phys(struct sas_ha_struct *sas_ha)
++{
++	int i;
++
++	for (i = 0 ; i < sas_ha->num_phys ; i++) {
++		struct asd_sas_phy *phy = sas_ha->sas_phy[i];
++
++		sas_phy_delete(phy->phy);
++		sas_phy_free(phy->phy);
++	}
+ }
+ 
+ const work_func_t sas_phy_event_fns[PHY_NUM_EVENTS] = {
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed
@@ -1,0 +1,45 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed.dummy_mainline_double
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed.dummy_mainline_double
@@ -1,0 +1,45 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v9.9.9.9 LOL
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed.dummy_mainline_single
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed.dummy_mainline_single
@@ -1,0 +1,45 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v9.9.9.9
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed.signed_off_by
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.all_fixed.signed_off_by
@@ -1,0 +1,45 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Signed-off-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.extracted
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.extracted
@@ -1,0 +1,42 @@
+From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+
+ drivers/scsi/st.c |    4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_header_only
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_header_only
@@ -1,0 +1,41 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_no_ack
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_no_ack
@@ -1,0 +1,44 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_no_ack_or_diffstat
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_no_ack_or_diffstat
@@ -1,0 +1,41 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_no_diffstat
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_no_diffstat
@@ -1,0 +1,42 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_update_only
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_update_only
@@ -1,0 +1,45 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_with_2nd_ref
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_with_2nd_ref
@@ -1,0 +1,46 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+References: Barney fake ref
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_with_double_fake_ref
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_with_double_fake_ref
@@ -1,0 +1,46 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+References: fake ref 1 fake-ref-2
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_with_single_fake_ref
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.fixed_with_single_fake_ref
@@ -1,0 +1,46 @@
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+References: fake ref
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.known_good
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.known_good
@@ -1,0 +1,42 @@
+From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.needs_fixing
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.needs_fixing
@@ -1,0 +1,42 @@
+From 8db816c6f176321e42254badd5c1a8df8bfcfdb4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.needs_fixing.no_diffstat
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.needs_fixing.no_diffstat
@@ -1,0 +1,39 @@
+From 8db816c6f176321e42254badd5c1a8df8bfcfdb4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.needs_fixing.with_reference
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.needs_fixing.with_reference
@@ -1,0 +1,43 @@
+From 8db816c6f176321e42254badd5c1a8df8bfcfdb4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kai=20M=C3=A4kisara?= <Kai.Makisara@kolumbus.fi>
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: [PATCH] scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+References: Barney
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+-- 
+2.52.0
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.signed_off_by
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.signed_off_by
@@ -1,0 +1,42 @@
+From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Signed-off-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference
@@ -1,0 +1,43 @@
+From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+References: some-reference
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference_twice
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference_twice
@@ -1,0 +1,43 @@
+From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+Date: Tue, 11 Mar 2025 13:25:16 +0200
+Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Git-commit: 8db816c6f176321e42254badd5c1a8df8bfcfdb4
+Patch-mainline: v6.15-rc1
+References: some-reference two more
+
+In the days when SCSI-2 was emerging, some drives did claim SCSI-2 but did
+not correctly implement it. The st driver first tries MODE SELECT with the
+page format bit set to set the block descriptor.  If not successful, the
+non-page format is tried.
+
+The test only tests the sense code and this triggers also from illegal
+parameter in the parameter list. The test is limited to "old" devices and
+made more strict to remove false alarms.
+
+Signed-off-by: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
+Link: https://lore.kernel.org/r/20250311112516.5548-4-Kai.Makisara@kolumbus.fi
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ drivers/scsi/st.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/st.c b/drivers/scsi/st.c
+index fda797581019..74a6830b7ed8 100644
+--- a/drivers/scsi/st.c
++++ b/drivers/scsi/st.c
+@@ -3104,7 +3104,9 @@ static int st_int_ioctl(struct scsi_tape *STp, unsigned int cmd_in, unsigned lon
+ 			   cmd_in == MTSETDRVBUFFER ||
+ 			   cmd_in == SET_DENS_AND_BLK) {
+ 			if (cmdstatp->sense_hdr.sense_key == ILLEGAL_REQUEST &&
+-			    !(STp->use_pf & PF_TESTED)) {
++				cmdstatp->sense_hdr.asc == 0x24 &&
++				(STp->device)->scsi_level <= SCSI_2 &&
++				!(STp->use_pf & PF_TESTED)) {
+ 				/* Try the other possible state of Page Format if not
+ 				   already tried */
+ 				STp->use_pf = (STp->use_pf ^ USE_PF) | PF_TESTED;
+

--- a/test/data/subject-and-ref-testing-file
+++ b/test/data/subject-and-ref-testing-file
@@ -1,0 +1,10 @@
+Subject: some subject and ref
+References: ref1 ref2 ref3
+
+
+
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ 0 files changed
+
+

--- a/test/data/subject-and-signed-off-by
+++ b/test/data/subject-and-signed-off-by
@@ -1,0 +1,7 @@
+Subject: some subject with signed-off-by
+
+Signed-off-by: Barney Rubbel <brubbel@suse.com>
+---
+ 0 files changed
+
+

--- a/test/data/subject-testing-file
+++ b/test/data/subject-testing-file
@@ -1,0 +1,9 @@
+Subject: testing file
+
+
+
+Acked-by: Barney Rubbel <brubbel@suse.com>
+---
+ 0 files changed
+
+

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -1,0 +1,657 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.11
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Regular expression matching correct parameter specification variable names.
+# If left empty, parameter specification variable names will be checked with
+# the set naming style.
+#paramspec-rgx=
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Regular expression matching correct type variable tuple names. If left empty,
+# type variable tuple names will be checked with the set naming style.
+#typevartuple-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line. Pylint's default of 100 is
+# based on PEP 8's guidance that teams may choose line lengths up to 99
+# characters.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# Whether or not to search for fixme's in docstrings.
+check-fixme-in-docstring=no
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/test/ruff.toml
+++ b/test/ruff.toml
@@ -1,0 +1,64 @@
+# Exclude a directory from linting
+exclude = ["data"]
+
+# Set the maximum line length
+line-length = 120
+
+[lint]
+select = [
+    "F",    # Pyflakes
+    "E",    # pycodestyle error
+    "W",    # pycodestyle warning
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "YTT",  # flake8-2020
+    "S",    # flake8-bandit
+    "B",    # flake8-bugbear
+    "A",    # flake8-builtins
+    "COM",  # flake8-commas
+    "C4",   # flake8-comprehensions
+    "EXE",  # flake8-executable
+    "FA",   # flake8-future-annotations
+    "ISC",  # flake8-implicit-str-concat
+    "ICN",  # flake8-import-conventions
+    "PIE",  # flake8-pie
+    "Q000", # use the proper quotes
+    "Q003", # flake8-quotes avoidable-escaped-quote
+    "Q004", # flake8-quotes unnecessary-escaped-quote
+    "RSE",  # flake8-raise
+    "RET",  # flake8-return
+    "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
+    "INT",  # flake8-gettext
+    "ARG",  # flake8-unused-argument
+    #"PTH", # flake8-use-pathlib TODO
+    "PL",   # Pylint
+    "FLY",  # flynt
+    "PERF", # Perflint
+    "FURB", # refurb
+    "RUF",  # Ruff
+    "PTH123", # prefer Path.open() over builtin open()
+    "D209", # docstrings check
+    # ignore these?
+    "I001", # Unsorted imports
+    "E722",  # do not use bare 'except'
+    "S104",  # Possible binding to all interfaces (0.0.0.0)
+    "B904",  # raise-without-from-inside-except
+    "ARG002", "PLR6301",  # Unused self, parameter in methods definitions
+    "PLR09",  # Too many branches/statements/arguments
+    "PLW1514", # `open` in text mode without explicit `encoding` argument
+]
+
+
+[lint.isort]
+# Configure isort-specific settings, like treating specific modules as first-party
+# first-party-alpine = ["my_application"] 
+
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+
+[format]
+quote-style = "single"
+indent-style = "space"

--- a/test/test_exportpatch.py
+++ b/test/test_exportpatch.py
@@ -1,0 +1,491 @@
+"""The test suite for the patchtools exportpatch command.
+
+Test the local patchtools package 'exportpatch' module,
+by calling the code directly.
+"""
+
+import filecmp
+import tempfile
+import unittest
+from pathlib import Path
+
+from .util import DATA_PATH, call_mut, compare_text_and_file, get_patch_path, import_mut
+
+# the module under test
+MUT = 'exportpatch'
+
+# commit for one file
+COMMIT_1F = '8db816c6f176321e42254badd5c1a8df8bfcfdb4'
+
+# commit for multiple files
+COMMIT_MF = '362432e9b9aefb914ab7d9f86c9fc384a6620c41'
+
+# a make-believe commit (as of 2026 -- let's hope its always bogus)
+COMMIT_BOGUS = '123456789abcde123456789abcde000000000077'
+
+# patch name for known commit (no suffix, etc)
+PATCH_1F = 'scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT'
+
+# patch name for known commit with multiple files
+PATCH_MF = 'scsi-libsas-Add-rollback-handling-when-an-error-occurs'
+
+# patchname for the one file in the simple commit
+PATCH_FILE_1F = 'drivers/scsi/st.c'
+
+# patch filename pattern for all files in multiple-file commit
+PATCH_FILE_PAT_MF = 'drivers/scsi/libsas/'
+
+# patch filenames for the patch with multiple commits
+PATCH_FILES_MF = [
+    'drivers/scsi/libsas/sas_init.c',
+    'drivers/scsi/libsas/sas_internal.h',
+    'drivers/scsi/libsas/sas_phy.c',
+    ]
+
+# patchname for one file in mulitple-file commit
+PATCH_FILE_FIRST_MF = 'drivers/scsi/libsas/sas_internal.h'
+
+mut = import_mut(MUT)
+
+
+class TestExportpatchNormalFunctionality(unittest.TestCase):
+    """Test normal functionality for 'exportpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')
+
+    def test_to_file_in_dir_defaults_1f(self):
+        """Test exportpatch of one file to file/dir, using defaults."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_in_dir_defaults_mf(self):
+        """Test exportpatch of multiple files to file/dir, using defaults."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_MF, dirname=tmpdir)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, COMMIT_MF])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_MF}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_in_dir_suffix(self):
+        """Test exportpatch to file/dir, with a suffix."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir, suffix='.patch')
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, '-s', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_numeric_default(self):
+        """Test exportpatch to file/dir, with numeric filename, using default start."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir, prefix='0001-')
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, '-n', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_numeric_s2(self):
+        """Test exportpatch to file/dir, with numeric filename, using start number 2."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir, prefix='0002-')
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, '-n', '-N', '2', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_numeric_w3(self):
+        """Test exportpatch to file/dir, with numeric filename, using width of 3."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir, prefix='001-')
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-n', '--num-width', '3', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_overwrite_force(self):
+        """Test exportpatch to file/dir, where patch already exists, using overwrite."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            patch_path_expected.touch()
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, '-f', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_overwrite_no_force(self):
+        """Test exportpatch to file/dir, where patch already exists, not using overwrite."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # create an empty 'patch' file, to creat a collision
+            patch_name_orig = get_patch_path(PATCH_1F, dirname=tmpdir)
+            patch_name_orig.touch()
+            # now set up for actual path for patch name expected
+            patch_path_expected = \
+                    patch_name_orig.with_name(f'{patch_name_orig.name}-{COMMIT_1F[0:8]}')
+            (res, pname, err_out) = call_mut(mut, MUT, ['-w', '-d', tmpdir, COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_stdout_defaults(self):
+        """Test exportpatch to stdout, using default arguments."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pbody, err_out) = call_mut(mut, MUT, [COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            res = compare_text_and_file(pbody, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+            self.assertFalse(patch_path_expected.exists(),
+                             'Patch file should not exist')
+
+    def test_to_file_in_cwd_defaults(self):
+        """Test exportpatch to file/current-dir, using default arguments."""
+        patch_path_expected = get_patch_path(PATCH_1F)
+        (res, pname, err_out) = call_mut(mut, MUT, ['-w', COMMIT_1F])
+        self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+        self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+        res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.known_good')
+        self.assertEqual(res, True, 'patch file differs from known good')
+        patch_path_expected.unlink()
+
+    def test_to_file_using_single_reference(self):
+        """Test exportpatch to file/dir, passing a single reference."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-F', 'some-reference', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.some_reference')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_using_double_reference(self):
+        """Test exportpatch to file/dir, passing a double reference."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT,
+                             ['-w', '-d', tmpdir, '-F', 'some-reference', '-F', 'two more', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{PATCH_1F}.some_reference_twice')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_file_using_signed_off_by(self):
+        """Test exportpatch to file/dir, using signed-off-by."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-S', COMMIT_1F])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.signed_off_by')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_to_files_two_commits(self):
+        """Test exportpatch to file/dir, with two commits."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected_1 = get_patch_path(PATCH_1F, dirname=tmpdir)
+            patch_path_expected_2 = get_patch_path(PATCH_MF, dirname=tmpdir)
+            (res, pnames, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, COMMIT_1F, COMMIT_MF])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            pname_arr = pnames.split()
+            self.assertEqual(len(pname_arr), 2, f'Needed 2 patchnames returned: {pnames}')
+            pname1, pname2 = pname_arr
+            self.assertEqual(pname1, patch_path_expected_1.name, 'first patch name wrong')
+            self.assertEqual(pname2, patch_path_expected_2.name, 'second patch name wrong')
+            res = filecmp.cmp(patch_path_expected_1, f'{DATA_PATH}/{PATCH_1F}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+            res = filecmp.cmp(patch_path_expected_2, f'{DATA_PATH}/{PATCH_MF}.known_good')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+
+class TestExportpatchExtract(unittest.TestCase):
+    """Test extract functionality for 'exportpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')
+
+    def test_extract_of_all_1f(self):
+        """Test exportpatch that extracts the one file in a patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-x', PATCH_FILE_1F, COMMIT_1F])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.extracted')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_extract_of_all_mf_pat(self):
+        """Test exportpatch that extracts all files in a patch using a pattern."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_MF, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-x', PATCH_FILE_PAT_MF, COMMIT_MF])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_MF}.2f_of_2')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_extract_of_all_mf_multiple_opts(self):
+        """Test exportpatch that extracts all files in a patch using multiple options."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_MF, dirname=tmpdir)
+            cmd_arr = ['-w', '-d', tmpdir]
+            for a_file in PATCH_FILES_MF:
+                cmd_arr += ['-x', a_file]
+            cmd_arr.append(COMMIT_MF)
+            (res, pname, err_out) = call_mut(mut, MUT, cmd_arr)
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_MF}.2f_of_2')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_extract_of_none_1f(self):
+        """Test exportpatch that extracts nothing from a patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (res, _, err_out) = call_mut(mut, MUT,
+                    ['-w', '-d', tmpdir, '-x', '/bogus/path', COMMIT_1F])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            # ensure we got an error message saying the patch was skipped
+            self.assertTrue('Skipping' in err_out, f'err_out={err_out}')
+
+    def test_extract_of_none_mf(self):
+        """Test exportpatch that extracts nothing from a patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (res, _, err_out) = call_mut(mut, MUT,
+                    ['-w', '-d', tmpdir, '-x', '/bogus/path', COMMIT_MF])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            # ensure we got an error message saying the patch was skipped
+            self.assertTrue('Skipping' in err_out, f'err_out={err_out}')
+
+    def test_extract_of_one_mf(self):
+        """Test exportpatch that extracts one file of two."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_MF, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-x', PATCH_FILES_MF[1], COMMIT_MF])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{PATCH_MF}.extracted_file2_of_3')
+
+
+class TestExportpatchExclude(unittest.TestCase):
+    """Test exclude functionality for 'exportpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')
+
+    def test_exclude_of_all_1f(self):
+        """Test exportpatch that excludes the only file in a single-file patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (res, _, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-X', PATCH_FILE_1F, COMMIT_1F])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            # ensure we got an error message saying the patch was skipped
+            self.assertTrue('Skipping' in err_out, f'err_out={err_out}')
+
+    def test_exlude_of_all_mf_pat(self):
+        """Test exportpatch that excludes all files in a patch using a pattern."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (res, _, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-X', PATCH_FILE_PAT_MF, COMMIT_MF])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            # ensure we got an error message saying the patch was skipped
+            self.assertTrue('Skipping' in err_out, f'err_out={err_out}')
+
+    def test_exlude_of_all_mf_multiple_opts(self):
+        """Test exportpatch that excludes all files with multiple options."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd_arr = ['-w', '-d', tmpdir]
+            for a_file in PATCH_FILES_MF:
+                cmd_arr += ['-X', a_file]
+            cmd_arr.append(COMMIT_MF)
+            (res, _, err_out) = call_mut(mut, MUT, cmd_arr)
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            # ensure we got an error message saying the patch was skipped
+            self.assertTrue('Skipping' in err_out, f'err_out={err_out}')
+
+    def test_exclude_of_none_1f(self):
+        """Test exportpatch exclude of nothing for 1 file patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_1F, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-X', '/abc/def', COMMIT_1F])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_1F}.extracted')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_exclude_of_none_mf(self):
+        """Test exportpatch exclude of nothing for mutliple file patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_MF, dirname=tmpdir)
+            (res, pname, err_out) = \
+                    call_mut(mut, MUT, ['-w', '-d', tmpdir, '-X', '/abc/def', COMMIT_MF])
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{PATCH_MF}.extracted')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_exclude_2f_of_multiple(self):
+        """Test exportpatch exclude 2 files of multiple files in a patch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(PATCH_MF, dirname=tmpdir)
+            cmd_arr = ['-w', '-d', tmpdir]
+            cmd_arr += ['-X', PATCH_FILES_MF[0]]
+            cmd_arr += ['-X', PATCH_FILES_MF[-1]]
+            cmd_arr.append(COMMIT_MF)
+            (res, pname, err_out) = call_mut(mut, MUT, cmd_arr)
+            self.assertEqual(res, 0, f'running {MUT} failed: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{PATCH_MF}.excluded_first_and_last')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+
+class TestExportpatchErrorCases(unittest.TestCase):
+    """Test error cases for 'exportpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')
+
+    def test_err_no_commit_supplied(self):
+        """Test exportpatch with no commit supplied."""
+        (res, _, err_out) = call_mut(mut, MUT, [])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('Must supply' in err_out, f'err_out={err_out}')
+
+    def test_err_invalid_commit_supplied(self):
+        """Test exportpatch with no commit supplied."""
+        (res, _, err_out) = call_mut(mut, MUT, ['HEAD'])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('must be hashes' in err_out, f'err_out={err_out}')
+
+    def test_err_bogus_commit(self):
+        """Test exportpatch with bogus commit."""
+        (res, _, err_out) = call_mut(mut, MUT, [COMMIT_BOGUS])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('Skipping' in err_out, f'err_out={err_out}')
+
+    def test_err_bogus_option_short(self):
+        """Test exportpatch with bogus argument(s)."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-z', COMMIT_BOGUS])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('no such option' in err_out, f'err_out={err_out}')
+
+    def test_err_bogus_args_long(self):
+        """Test exportpatch with bogus argument(s)."""
+        (res, _, err_out) = call_mut(mut, MUT, ['--zebra', COMMIT_BOGUS])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('no such option' in err_out, f'err_out={err_out}')
+
+    def test_err_num_width_no_commit(self):
+        """Test exportpatch with num-width argument with no argument, with no commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['--num-width'])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('requires 1 argument' in err_out, f'err_out={err_out}')
+
+    def test_err_num_width_bogus_commit(self):
+        """Test exportpatch with num-width argument with bogus value, with a commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['--num-width', 'XX', COMMIT_BOGUS])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('invalid integer value' in err_out, f'err_out={err_out}')
+
+    def test_err_num_width_valid_commit(self):
+        """Test exportpatch with num-width argument with bogus value, with a valid commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['--num-width', 'XX', COMMIT_1F])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('invalid integer value' in err_out, f'err_out={err_out}')
+
+    def test_err_first_number_no_commit(self):
+        """Test exportpatch with first-number argument with no argument, with no commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-N'])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('requires 1 argument' in err_out, f'err_out={err_out}')
+
+    def test_err_first_number_bogus_commit(self):
+        """Test exportpatch with first-number argument with bogus value, with a bogus commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-N', 'XX', COMMIT_BOGUS])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('invalid integer value' in err_out, f'err_out={err_out}')
+
+    def test_err_first_number_valid(self):
+        """Test exportpatch with first-number argument with bogus value, with a valid commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-N', 'XX', COMMIT_1F])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('invalid integer value' in err_out, f'err_out={err_out}')
+
+    def test_err_first_number_out_of_range_too_large(self):
+        """Test exportpatch with first-number argument with out of range."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-N', '9999', COMMIT_1F])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('needs to be in the range' in err_out, f'err_out={err_out}')
+
+    def test_err_first_number_out_of_range_too_small(self):
+        """Test exportpatch with first-number argument with out of range."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-N', '-1', COMMIT_BOGUS])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('needs to be in the range' in err_out, f'err_out={err_out}')
+
+    def test_err_reference_with_no_value(self):
+        """Test exportpatch with reference with no argument."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-F'])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('requires 1 argument' in err_out, f'err_out={err_out}')
+
+    def test_err_export_to_dir_no_value(self):
+        """Test exportpatch write to a dir with no argument and no commit."""
+        (res, _, err_out) = call_mut(mut, MUT, ['-d'])
+        self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('requires 1 argument' in err_out, f'err_out={err_out}')
+
+    def test_err_export_to_dir_no_commit(self):
+        """Test exportpatch write to a dir with no commit."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (res, _, err_out) = call_mut(mut, MUT, ['-d', tmpdir])
+            self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('Must supply' in err_out, f'err_out={err_out}')
+
+    def test_err_export_to_dir_does_not_exist(self):
+        """Test exportpatch write to a dir that does not exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_dir = Path(tmpdir) / 'some_bogus_dir'
+            (res, _, err_out) = call_mut(mut, MUT, ['-w', '-d', fake_dir, COMMIT_1F])
+            self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('No such file or directory' in err_out, f'err_out={err_out}')
+
+    def test_err_export_to_dir_readonly(self):
+        """Test exportpatch write to a dir that does exist but is readonly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_dir = Path(tmpdir) / 'some_subdir'
+            new_dir.mkdir(mode=0o511)
+            (res, _, err_out) = call_mut(mut, MUT, ['-w', '-d', new_dir, COMMIT_1F])
+            self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('Permission denied' in err_out, f'err_out={err_out}')

--- a/test/test_fixpatch.py
+++ b/test/test_fixpatch.py
@@ -1,0 +1,432 @@
+"""The test suite for the patchtools fixpatch command.
+
+Test the local patchtools package 'fixpatch' module,
+by calling the code directly.
+"""
+
+import filecmp
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from .util import DATA_PATH, call_mut, compare_text_and_file, get_patch_path, import_mut
+
+# the module under test (and the command/script name, as well)
+MUT = 'fixpatch'
+
+# simple filename for a patch to be fixed (using 1 file)
+FIX_FILE_1F = 'scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT'
+
+# some mostly-empty subject testing files, after fixing
+SUBJECT_TESTING_FILE = 'subject-testing-file'
+SUBJECT_AND_REF_TESTING_FILE = 'subject-and-ref-testing-file'
+SUBJECT_AND_SIGNED_OFF_BY = 'subject-and-signed-off-by'
+
+mut = import_mut(MUT)
+
+
+class TestFixpatchNormalFunctionality(unittest.TestCase):
+    """Test normal functionality for 'fixpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')
+
+    def test_fixpatch_renaming(self):
+        """Test fixpatch fix and rename."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, [fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_no_renaming(self):
+        """Test fixpatch without rename."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('temp', dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-r', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_add_suffix(self):
+        """Test fixpatch rename with a suffix."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F,
+                                                 dirname=tmpdir,
+                                                 suffix='.patch',
+                                                 truncate=None)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-s', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected, f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_dry_run(self):
+        """Test fixpatch dry run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_src = f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing'
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(fixpatch_src, fixpatch_dest)
+            (res, pbody, err_out) = call_mut(mut, MUT, ['-n', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            res = compare_text_and_file(pbody,
+                                        f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed')
+            self.assertEqual(res, True, 'patch file differs from known good')
+            self.assertFalse(patch_path_expected.exists(),
+                             'Patch file should not exist')
+
+    def test_fixpatch_no_force_on(self):
+        """Test fixpatch rename with name collision, no force."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            patch_path_expected.touch()
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, _, err_out) = call_mut(mut, MUT, [fixpatch_dest])
+            self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('already exists' in err_out,
+                            f'err_out={err_out}, expected={patch_path_expected.resolve()}')
+
+    def test_fixpatch_name_only(self):
+        """Test fixpatch name-only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-R', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name
+                             , 'patch name wrong')
+            self.assertFalse(patch_path_expected.exists(),
+                             'Patch file should not exist')
+
+    def test_fixpatch_name_only_with_suffix(self):
+        """Test fixpatch name-only mode, with suffix."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F,
+                                                 dirname=tmpdir,
+                                                 suffix='.patch',
+                                                 truncate=None)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-s', '-R', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.name, 'patch name wrong')
+            self.assertFalse(patch_path_expected.exists(), 'Patch file should not exist')
+
+    def test_fixpatch_no_ack(self):
+        """Test fixpatch fixing rename, without ack."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-N', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_no_ack')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_no_diffstat_added(self):
+        """Test fixpatch rename, without adding diffstat."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing.no_diffstat',
+                         fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-D', fixpatch_dest])
+            self.assertEqual(res, 0,
+                             f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_no_diffstat')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_header_only(self):
+        """Test fixpatch rename, without adding diffstat or ack."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing.no_diffstat',
+                         fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-H', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_no_ack_or_diffstat')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_update_only(self):
+        """Test fixpatch, without adding diffstat, ack, or renaming."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('temp', dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing.no_diffstat',
+                         fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-U', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_no_ack_or_diffstat')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_setting_first_reference(self):
+        """Test fixpatch rename, with a new reference."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-F', 'fake ref', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_with_single_fake_ref')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_setting_second_reference(self):
+        """Test fixpatch rename, with a 2nd reference."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing.with_reference',
+                         fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-F', 'fake ref', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_with_2nd_ref')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_setting_two_references(self):
+        """Test fixpatch rename, with a new reference."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing',
+                         fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT,
+                    ['-F', 'fake ref 1', '-F', 'fake-ref-2', fixpatch_dest])
+            self.assertEqual(res, 0,
+                             f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_with_double_fake_ref')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_setting_reference_header_only(self):
+        """Test fixpatch rename, with a reference, and header-only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing.no_diffstat',
+                         fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-H', '-F', 'fake ref', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.fixed_header_only')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_adding_existing_reference(self):
+        """Test fixpatch rename, mostly empty patch, testing existing & new references."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('some-subject-and-ref',
+                                                 dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            with Path(fixpatch_dest).open('w', encoding='utf-8') as f:
+                print('Subject: some subject and ref', file=f)
+                print('References: ref1 ref2', file=f)
+            (res, pname, err_out) = call_mut(mut, MUT,
+                    ['-F', 'ref3', '-F', 'ref1', fixpatch_dest])
+            self.assertEqual(res, 0,
+                             f'calling {MUT} returned failure: {res} ({err_out}i')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{SUBJECT_AND_REF_TESTING_FILE}')
+            self.assertEqual(res, True, 'patch file differs from expected')
+
+    def test_fixpatch_signed_off_by(self):
+        """Test fixpatch rename, with signed-off-by."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT, ['-S', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(),
+                             patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed.signed_off_by')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_dummy_mainline_single(self):
+        """Test fixpatch rename, with a single dummy mainline."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut,
+                                             MUT, ['-M', 'v9.9.9.9', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed.dummy_mainline_single')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_dummy_mainline_dual(self):
+        """Test fixpatch rename, with twoo dummy mainlines."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path(FIX_FILE_1F, dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            (res, pname, err_out) = call_mut(mut, MUT,
+                    ['-M', 'v9.9.9.9', '-M', 'LOL', fixpatch_dest])
+            self.assertEqual(res, 0, f'calling {MUT} returned faliure: {err_out}')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.all_fixed.dummy_mainline_double')
+            self.assertEqual(res, True, 'patch file differs from known good')
+
+    def test_fixpatch_signed_off_by_alredy_there(self):
+        """Test fixpatch rename, mostly empty patch, where signed-off-by already there."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('some-subject-with-signed-off-by',
+                                                 dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            with Path(fixpatch_dest).open('w', encoding='utf-8') as f:
+                print('Subject: some subject with signed-off-by', file=f)
+                print(file=f)
+                print('Signed-off-by: Barney Rubbel <brubbel@suse.com>', file=f)
+            (res, pname, err_out) = call_mut(mut, MUT, [fixpatch_dest])
+            self.assertEqual(res, 0,
+                             f'calling {MUT} returned failure: {res} ({err_out}i')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{SUBJECT_AND_SIGNED_OFF_BY}')
+            self.assertEqual(res, True, 'patch file differs from expected')
+
+
+class TestFixpatchErrorCases(unittest.TestCase):
+    """Test error cases for 'fixpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')
+
+    def test_err_bogus_option_long(self):
+        """Test fixpatch with no patch filename supplied."""
+        (res, _, err_out) = call_mut(mut, MUT, ['--zzz'])
+        self.assertEqual(res, 1,
+                         f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('no such option' in err_out, f'err_out={err_out}')
+
+    def test_err_no_patchname_supplied(self):
+        """Test fixpatch with no patch filename supplied."""
+        (res, _, err_out) = call_mut(mut, MUT, [])
+        self.assertEqual(res, 1,
+                         f'calling {MUT} expected return of 1, got {res}')
+        self.assertTrue('Must supply' in err_out, f'err_out={err_out}')
+
+    def test_err_bogus_filename_supplied(self):
+        """Test fixpatch with a bogus patch filename supplied."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            non_existant_file_path = Path(tmpdir) / 'bogus'
+            (res, _, err_out) = call_mut(mut, MUT,
+                                         [non_existant_file_path.as_posix()])
+            self.assertEqual(res, 1,
+                             f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('No such file or directory' in err_out,
+                            f'err_out={err_out}')
+
+    def test_err_no_rename_patch_readonly(self):
+        """Test fixpatch no-rename but patch is read only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('temp', dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            Path(fixpatch_dest).chmod(0o444)
+            (res, _, err_out) = call_mut(mut, MUT, ['-r', fixpatch_dest])
+            self.assertEqual(res, 1,
+                             f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('Permission denied' in err_out,
+                            f'err_out={err_out}')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing')
+            self.assertEqual(res, True, 'patch file changed when it should not have')
+
+    def test_err_rename_patch_readonly_dir(self):
+        """Test fixpatch rename but directory is read only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('temp', dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            shutil.copy2(f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing', fixpatch_dest)
+            Path(tmpdir).chmod(0o555)
+            (res, _, err_out) = call_mut(mut, MUT, [fixpatch_dest])
+            self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('Permission denied' in err_out, f'err_out={err_out}')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{FIX_FILE_1F}.needs_fixing')
+            self.assertEqual(res, True,
+                             'patch file changed when it should not have')
+
+    def test_err_empty_patch_no_subject(self):
+        """Test fixpatch with an empty file, triggering a no-subject error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixpatch_dest = f'{tmpdir}/temp'
+            Path(fixpatch_dest).touch()
+            (res, _, err_out) = call_mut(mut, MUT, [fixpatch_dest])
+            self.assertEqual(res, 1, f'calling {MUT} expected return of 1, got {res}')
+            self.assertTrue('no Subject line' in err_out,
+                            f'err_out={err_out}')
+
+    def test_err_mostly_empty_patch_with_subject_line(self):
+        """Test fixpatch with mostly empty file, having only a Subject line."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            patch_path_expected = get_patch_path('testing-file', dirname=tmpdir)
+            fixpatch_dest = f'{tmpdir}/temp'
+            Path(fixpatch_dest).write_text('Subject: testing file', encoding='utf-8')
+            (res, pname, err_out) = call_mut(mut, MUT, [fixpatch_dest])
+            self.assertEqual(res, 0,
+                             f'calling {MUT} returned failure: {res} ({err_out}i')
+            self.assertEqual(pname.strip(), patch_path_expected.as_posix(),
+                             'patch name wrong')
+            res = filecmp.cmp(patch_path_expected,
+                              f'{DATA_PATH}/{SUBJECT_TESTING_FILE}')
+            self.assertEqual(res, True, 'patch file differs from expected')

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -1,0 +1,25 @@
+"""The test suite for the patchtools fixpatch command.
+
+Test the local patchtools package 'patch' module,
+by calling the exportpatch or fixpatch as needed.
+"""
+
+import unittest
+
+from .util import DATA_PATH, call_mut, get_patch_path, import_mut
+
+# the module under test
+FIXPATCH = 'fixpatch'
+EXPORTPATCH = 'exportpatch'
+
+# simple filename for a patch to be fixed (using 1 file)
+FIX_FILE_1F = 'scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT'
+
+
+class TestPatchModuleNormalFunctionality(unittest.TestCase):
+    """Test normal functionality for 'fixpatch'."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test class for this class. Done once per class."""
+        cls.assertTrue(DATA_PATH, 'cannot find "data" subdirectory')

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,132 @@
+"""Utility functions, common to test_*.py test modules."""
+
+import filecmp
+import importlib
+import io
+import os
+import sys
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+# template for the patch.cfg file we create
+PATCH_CFG_TEMPLATE = [
+    '[repositories]',
+    'search:',
+    '  @PATHNAME@',
+    '',
+    '[contact]',
+    'name: Barney Rubbel',
+    'email: brubbel@suse.com',
+    ]
+
+
+def get_git_repo_dir():
+    """Get a valid Linux git repo path.
+
+    Return results as (success/failure, pathname/error_msg).
+
+    For now, get repo path from environment variable LINUX_GIT.
+    """
+    linux_git_dir = os.getenv('LINUX_GIT')
+    if not linux_git_dir:
+        return (False, 'No LINUX_GIT environment variable found')
+    if not Path(linux_git_dir).exists():
+        return (False, f'LINUX_GIT directory not found: {linux_git_dir}')
+    return (True, linux_git_dir)
+
+
+def create_config_file():
+    """Create a minimal config file, for testing.
+
+    Return (success/failure, error_msg/filename).
+    """
+    (ok, git_repo_reply) = get_git_repo_dir()
+    if not ok:
+        print(f'Error: {git_repo_reply}')
+        return None
+    cfp = Path('patch.cfg')
+    with cfp.open('w', encoding='utf-8') as configf:
+        for aline in PATCH_CFG_TEMPLATE:
+            if '@PATHNAME@' in aline:
+                print(aline.replace('@PATHNAME@', git_repo_reply), file=configf)
+            else:
+                print(aline, file=configf)
+    return cfp
+
+
+def import_mut(modname):
+    """Import our module under test."""
+    try:
+        configp = create_config_file()
+        dynamic_mod = importlib.import_module(f'patchtools.{modname}')
+        main_under_test = dynamic_mod.main
+        configp.unlink()
+    finally:
+        pass
+    return main_under_test
+
+
+def call_mut(mut_func, mut, arg_array):
+    """Call the modulue under test, passing in the specified arguments.
+
+    We capture stdout and stderr from the test code and return it.
+    """
+    save_argv = sys.argv
+    sys.argv = [mut, *arg_array]
+    captured_stdout = io.StringIO()
+    captured_stderr = io.StringIO()
+    with redirect_stdout(captured_stdout), redirect_stderr(captured_stderr):
+        res = mut_func()
+    sys.argv = save_argv
+    return (res, captured_stdout.getvalue(), captured_stderr.getvalue())
+
+
+def find_data_dir_path():
+    """Find the 'data' directory path, if possible.
+
+    This is the directory where known-good patch files
+    are kept.
+
+    Look first in the current directory. If not there,
+    then look for a 'test' subdirectory, and look there.
+    """
+    for data_pathname in ['data', 'test/data', '../data', '../test/data']:
+        data_path = Path(data_pathname)
+        if data_path.is_dir():
+            return data_path
+    return None
+
+
+# set the data directory
+DATA_PATH = find_data_dir_path()
+
+
+def get_patch_path(fname, dirname=None, prefix='', suffix='', truncate=64):
+    """Return a patch filename, optionally truncated.
+
+    The truncation code is copied in part from patch.py, so we match it.
+
+    The truncation is used by exportpatch, but not fixpatch.
+    """
+    if truncate is not None:
+        truncate_chars = truncate - len(fname) - len(prefix + suffix)
+        if truncate_chars < 0:
+            fname = fname[0:truncate_chars]
+    fpath = Path(prefix + fname + suffix)
+    if dirname:
+        fpath = Path(dirname) / fpath
+    return fpath
+
+
+def compare_text_and_file(pbody, fname):
+    """Compare supplied patch body with contents of fname."""
+    # write out our patch to our temp file into a temporary file
+    tmpfd, tmpname = tempfile.mkstemp(text=True)
+    try:
+        with os.fdopen(tmpfd, 'w', encoding='utf-8') as tmpf:
+            tmpf.write(pbody)
+        res = filecmp.cmp(tmpname, fname)
+    finally:
+        os.remove(tmpname)
+    return res


### PR DESCRIPTION
This set of commits fixes some bugs, rearranges the code slightly to allow for unit testing, and adds a set of unit tests.

The "bugs" range from actual bugs (like adding a header twice) to cleanup of help messages.

Code rearrangement involves moving scripts/exportpatch and scripts/fixpatch to patchtools/exportpatch.py and patchtools/fixpatch.py, and adding info to the setup.py to automatically create front ends for these two scripts.

Most changes are in fixpatch.py and exportpatch.py, with one change/bug fix in patch.py.

Code coverage from the unit tests seems pretty good, but the plan is to add more tests later. Here's the coverage report:

```
Name                        Stmts   Miss  Cover
-----------------------------------------------
patchtools/__init__.py          7      0   100%
patchtools/command.py           5      0   100%
patchtools/config.py           64      8    88%
patchtools/exportpatch.py      98      0   100%
patchtools/fixpatch.py        100      0   100%
patchtools/patch.py           378    126    67%
patchtools/patchops.py         90     44    51%
-----------------------------------------------
TOTAL                         742    178    76%
```
