### PR TITLE
Update man pages with latest information

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,3 @@
+patchtools.cfg.5.gz
+exportpatch.1.gz
+fixpatch.1.gz

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,7 +13,7 @@ mandir ?= $(prefix)/share/man
 man1dir = $(mandir)/man1
 man5dir = $(mandir)/man5
 
-PATCHTOOLS_VERSION = $(shell python ../setup.py --version 2> /dev/null)
+PATCHTOOLS_VERSION = $(shell python3 ../setup.py --version 2> /dev/null)
 
 GZ_MAN1 = $(patsubst %.asciidoc,%.1.gz,$(MAN1_TXT))
 GZ_MAN5 = $(patsubst %.asciidoc,%.5.gz,$(MAN5_TXT))

--- a/doc/exportpatch.asciidoc
+++ b/doc/exportpatch.asciidoc
@@ -7,29 +7,36 @@ exportpatch - a tool to export patches from git with proper tags
 
 SYNOPSIS
 --------
-*exportpatch* [options] <commit> [commits..]
+*exportpatch* [options] <commit> [<commit> ...]
 
 DESCRIPTION
 -----------
-The *exportpatch* utility is a tool for exporting patches from git repositories
-with the tags that are expected for import into the SUSE kernel-source
-repository.
+The *exportpatch* utility is a tool for exporting one or more patches
+rom git repositories with the tags that are expected for import into
+the SUSE kernel-source repository.
 
-It is a requirement that the commit is contained in the git remote repository
+It is a requirement that each 'commit' is contained in the git remote repository
 as well as the local repository, though this can be overridden using the '-f'
 option.
 
-The behavior of exportpatch is controlled by the options below and the
-*patchtools.cfg(5)* configuration files.  If no configuration files are
+The behavior of *exportpatch* is controlled by the options below and the
+*patchtools.cfg(5)* configuration files. If no configuration files are
 available, *exportpatch* defaults to using the current directory as a
 git repository, the email address configured for use with git, and the
 user's real name from the system password database.
 
+All listed commits are exported as patch files, with processing halted if
+an error is detected.
+
 TAGS
 ----
+The following are the patch header tags that *exportpatch* can add
+to the exported patch file:
 
 *Git-commit*::
-All exported patches will contain a 'Git-commit' tag that identifies the commit that contains the patch.  It uses the full 40-character SHA1 hash.
+All exported patches will contain a 'Git-commit' tag that
+identifies the commit that contains the patch.
+It uses the full 40-character SHA1 hash.
 +
 When using the '--extract' or '--exclude' options documented below, this tag will
 also contain the text "(partial)" to identify it as incomplete.
@@ -39,7 +46,8 @@ When the repository is not a clone of an upstream "mainline" repository, this
 tag will contain the URL of the remote repository.
 
 *Patch-mainline*::
-If the repository is identified as a clone of the upstream "mainline" repository, this tag will contain the text of the oldest tag to contain this commit.
+If the repository is identified as a clone of the upstream "mainline" repository,
+this tag will contain the text of the oldest tag to contain this commit.
 +
 By default, the list of upstream mainline repositories is as follows, but can
 be extended using *patch.cfg(5)*.
@@ -47,98 +55,117 @@ be extended using *patch.cfg(5)*.
 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-2.6.git
 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 +
-If the commit originated in a repository that is not an upstream mainline clone, it is assumed to have originated in a subsystem maintainer repository and the tag will contain "Queued in subsystem maintainer repository" instead of a version tag.  A 'Git-repo' tag will also be automatically added.
+If the commit originated in a repository that is not an upstream mainline clone,
+it is assumed to have originated in a subsystem maintainer repository and
+the tag will contain "Queued in subsystem maintainer repository" instead of a version tag.
+A 'Git-repo' tag will also be automatically added.
 
 *Acked-by*::
-If the patch doesn't already contained an 'Acked-by' or 'Signed-off-by' tag with the configured email address, an 'Acked-by' tag will be added to the patch unless the '--signed-off-by' option is used.
+If the patch doesn't already contain an 'Acked-by' or 'Signed-off-by' tag
+with the configured email address, an 'Acked-by' tag will be added to the
+patch unless the '--signed-off-by' option is used.
 
 *References*::
-A 'References' tag can optionally be added.  Only one tag will be exported.  It can contain multiple references.
+A 'References' tag can optionally be added. Only one tag will be exported.
+It can contain multiple references.
+The following are suggested values for the 'References' tag.
 
 Bugzilla:::
-A bugzilla identifier prefixed with 'bsc#' e.g. 'bsc#123450'.  Other bugzilla instances can be specified using a similar abbreviation.
+A bugzilla identifier prefixed with 'bsc#' e.g. 'bsc#123450'.
+Other bugzilla instances can be specified using a similar abbreviation.
 
-FATE:::
-The content should be a feature request ID prefixed with "FATE#"
+JIRA:::
+The content should be a JIRA feature request ID prefixed with 'jsc#',
+e.g. 'jsc#PED-348'.
 
 *Patch-filtered*::
-When the '--extract' or '--exclude' options are used, the patch will contain a 'Patch-filtered' tag indicating what filters were used when exporting the commit.
+When the '--extract' or '--exclude' options are used,
+the patch will contain a 'Patch-filtered' tag indicating
+what filters were used when exporting the commit.
 
 OPTIONS
 -------
 
 *--version*::
-show program's version number and exit
+Show program's version number and exit.
 
-*-h | --help*::
-show help message and exit
+*-h*, *--help*::
+Show help message and exit.
 
-*-w | --write*::
-Write the output to file(s) instead of stdout.  Default is to write to stdout.
+*-w*, *--write*::
+Write the output to file(s) instead of 'stdout'. Default is to write to 'stdout'.
 The filenames default to being a "safe" version of the commit's summary and
-can be modified using some of the options below.
+can be modified using some of the options below, which can add a numeric
+prefix (see '-n'), and/or a suffix (see '-s'). The filename length is limited
+to 64 characters, since subject lines can be arbitrarily long.
 +
-The filename(s) are output on stdout in the order the commits were specified.  This output can be captured to provide a series file for consumption by *quilt(1)*.
+If writing to 'stdout', the patch file(s) are output in the order the commits were specified.
+This output can be captured to provide a series file for consumption by *quilt(1)*.
 
-*-s | --suffix*::
-When used with --write, append .patch suffix to filenames.
+*-s*, *--suffix*::
+When used with '--write', append '.patch' suffix to filenames.
 
-*-n | --numeric*::
-When used with --write, prepend order numbers to filenames.  This will produce
-filenames prefixed with 0001-, 0002-, etc.
+*-n*, *--numeric*::
+When used with '--write', prepend order numbers to filenames. This will produce
+filenames prefixed with '0001-', '0002-', etc.
 
-*-N FIRST_NUMBER | --first-number=FIRST_NUMBER*::
-When used with --numeric, start the number at FIRST_NUMBER instead of 1.
+*-N FIRST_NUMBER*, *--first-number=FIRST_NUMBER*::
+When used with '--numeric', start the number at *FIRST_NUMBER* instead of 1.
 
-*-d DIR | --dir=DIR*::
+*-d DIR*, *--dir=DIR*::
 Instead of writing the patch(es) to the current directory, write them to
-DIR.
+*DIR*.
 
-*-f | --force*::
-By default, exportpatch will not overwrite existing files or export a commit
-that only exists in the local repository.  The latter behavior is a protection
+*-f*, *--force*::
+By default, *exportpatch* will not overwrite existing files or export a commit
+that only exists in the local repository. The latter behavior is a protection
 against adding patches to the kernel repository that look like they are
 upstream at a glance but are not.
 
-*-D | --debug*::
+*-D*, *--debug*::
 Enable more verbose debugging output.
 
-*-F REFERENCE | --reference=REFERENCE*::
-Add a References tag to the patch output using the specified reference.
+*-F REFERENCE*, *--reference=REFERENCE*::
+Add a 'References' tag to the patch output using the specified reference.
 +
 This option may be specified multiple times.
 
-*-x EXTRACT | --extract=EXTRACT*::
-Extract specific parts of the commit.  EXTRACT is a pathname.  If the path
-ends with /, it includes all files under that hierarchy.
+*-x EXTRACT*, *--extract=EXTRACT*::
+Extract specific parts of the commit. *EXTRACT* is a pathname. If the path
+ends with '/', it includes all files under that hierarchy.
 +
 This option may be specified multiple times.
 +
-Use of this option is documented in the patch output by appending "(partial)" to the Git-commit tag and adding one or more Patch-filtered tags that contain the paths extracted.
+Use of this option is documented in the patch output by appending "(partial)"
+to the Git-commit tag and adding one or more Patch-filtered tags that contain the paths extracted.
 
-*-X EXCLUDE | --exclude=EXCLUDE*::
-Exclude specific parts of the commit.  EXCLUDE is as pathname.  If the patch
-ends with /, it excludes all files under that hierarchy.
+*-X EXCLUDE*, *--exclude=EXCLUDE*::
+Exclude specific parts of the commit. *EXCLUDE* is as pathname. If the path
+ends with '/', it excludes all files under that hierarchy.
 +
 This option may be specified multiple times.
 +
-Use of this option is documented in the patch output by appending "(partial)" to the Git-commit tag and adding one or more Patch-filtered tags that contain the paths excluded.
+Use of this option is documented in the patch output by appending "(partial)"
+to the 'Git-commit' tag and adding one or more 'Patch-filtered'
+tags that contain the paths excluded.
 
-*-S | --signed-off-by*::
-By default, every patch exported has the user's "Acked-by" tag added to it.  This option uses the Signed-off-by tag instead of Acked-by.
+*-S*, *--signed-off-by*::
+By default, every patch exported has the user's 'Acked-by' tag added to it.
+This option uses the 'Signed-off-by' tag instead of 'Acked-by'.
 
 EXIT STATUS
 -----------
-*exportpatch* returns a zero exit status if it succeeds.  Non zero is returned
+*exportpatch* returns a zero exit status if it succeeds. Non-zero is returned
 in case of failure.
 
 AVAILABILITY
 ------------
-*exportpatch* is part of Patchtools.
-Please refer to the GitHub repository at https://github.com/jeffmahoney/jpt for more information.
+*exportpatch* is part of patchtools.
+Please refer to the GitHub repository
+at https://github.com/opensuse/patchtools for more information.
 
 SEE ALSO
 --------
-`fixpatch`(1)
-`patch.cfg(5)`
-`git`(1)
+fixpatch(1),
+patch.cfg(5),
+git(1)

--- a/doc/fixpatch.asciidoc
+++ b/doc/fixpatch.asciidoc
@@ -7,94 +7,103 @@ fixpatch - a tool to fix already exported patches
 
 SYNOPSIS
 --------
-*fixpatch* [options] <patch>
+*fixpatch* [options] <patch> [<patch> ...]
 
 DESCRIPTION
 -----------
 The *fixpatch* utility is a tool for fixing common issues with patches that
-have already been exported from a git repository using `exportpatch(1)`, `git-send-email(1)` or `gitweb(1)` raw commit text functionality.
-
+have already been exported from a git repository using `exportpatch(1)`,
+`git-send-email(1)` or `gitweb(1)` raw commit text functionality.
 
 The behavior of *fixpatch* is controlled by the options below and the
-*patchtools.cfg(5)* configuration files.  If no configuration files are
+*patchtools.cfg(5)* configuration files. If no configuration files are
 available, *fixpatch* defaults to using the current directory as a
-git repository, the email address configured for use with git, and the
+git repository, the email address configured for use with *git*, and the
 user's real name from the system password database.
 
 Unless otherwise specified, default options are to:
 
-* add any missing 'Acked-by' tag
-* add a diffstat of the patch between the commit text and the patch content
-* rename the patch to a lower-case "safe" version of the patch subject
-* detect and use a commit id detected in the patch content to generate a proper 'Git-commit' tag
+* Add any missing 'Acked-by' tag.
+* Add a diffstat of the patch between the commit text and the patch content.
+* Rename the patch to a lower-case "safe" version of the patch subject,
+with optional suffix (see '-s-' below).
+* Detect and use a commit id detected in the patch content to generate a
+proper 'Git-commit' tag.
 ** 'X-Git-Url' header added by `gitweb(1)`
 ** Unix-style mbox 'From' (no colon)
-* use the 'Git-commit' tag to resolve 'Patch-mainline' and 'Git-repo' tags, if any
+* Use the 'Git-commit' tag to resolve 'Patch-mainline' and 'Git-repo' tags, if any.
 
 TAGS
 ----
-
 Please see the *TAGS* section in the manual page for `exportpatch(1)` for
 descriptions of individual tag contents.
 
 OPTIONS
 -------
-
 *--version*::
-show program's version number and exit
+Show program's version number and exit.
 
-*-h | --help*::
-show help message and exit
+*-h*, *--help*::
+Show help message and exit.
 
-*-n | --dry-run*::
+*-n*, *--dry-run*::
 Output the results to stdout instead of overwriting the file.
 
-*-N | --no-ack*::
+*-N*, *--no-ack*::
 Don't add the Acked-by tag.
 
-*-D | --no-diffstat*::
+*-D*, *--no-diffstat*::
 Don't add the diffstat to the patch.
 
-*-r | --no-rename*::
+*-r*, *--no-rename*::
 Don't rename the patch file.
 
-*-f | --force*::
+*-f*, *--force*::
 Overwrite any existing file with the same name.
 
-*-H | --header-only*::
-Only resolve headers ('Patch-mainline', 'Git-repo', etc), don't do Acked-by or diffstat.
+*-H*, *--header-only*::
+Only resolve headers ('Patch-mainline', 'Git-repo', etc),
+don't do 'Acked-by' or diffstat.
 
-*-U | --update-only*::
-Update the headers as with '--header-only' but don't rename the file.  This is shorthand for '--no-rename --header-only'.
+*-U*, *--update-only*::
+Update the headers as with '--header-only' but don't rename the file.
+This is shorthand for '--no-rename' and '--header-only'.
 
-*-R | --name-only*::
+*-R*, *--name-only*::
 Output the file name that would be used for output and exit.
 
-*-F | --reference*::
+*-F*, *--reference*::
 Add the specified 'References' tag.
++
+This option may be specified multiple times.
 
-*-S | --signed-off-by*::
+*-S*, *--signed-off-by*::
 Add a 'Signed-off-by' tag instead of 'Acked-by'.
 
-*-M MAINLINE | --mainline=MAINLINE*::
-Add a dummy 'Patch-mainline' tag with the contents specified in 'MAINLINE'.  No validity checking will be performed.
+*-M MAINLINE*, *--mainline=MAINLINE*::
+Add a 'Patch-mainline' tag with the contents specified in 'MAINLINE'.
+No validity checking will be performed. Any existing 'Patch-mainline' tag will
+be replaced.
++
+This option may be specified multiple times.
 
-*-s | --suffix*::
-Append '.patch' to the output filename.
+*-s*, *--suffix*::
+Append '.patch' to the output filename, if renaming the patch file.
 
 EXIT STATUS
 -----------
-*fixpatch* returns a zero exit status if it succeeds.  Non zero is returned
+*fixpatch* returns a zero exit status if it succeeds. Non zero is returned
 in case of failure.
 
 AVAILABILITY
 ------------
-*fixpatch* is part of Patchtools.
-Please refer to the GitHub repository at https://github.com/jeffmahoney/jpt for more information.
+*fixpatch* is part of patchtools.
+Please refer to the GitHub repository
+at https://github.com/opensuse/patchtools for more information.
 
 SEE ALSO
 --------
-`exportpatch`(1)
-`patch.cfg(5)`
-`git`(1)
-`git-send-email(1)`
+exportpatch(1),
+patch.cfg(5),
+git(1),
+git-send-email(1)

--- a/doc/patchtools.cfg.asciidoc
+++ b/doc/patchtools.cfg.asciidoc
@@ -14,21 +14,20 @@ DESCRIPTION
 -----------
 The search order is as follows:
 
-* /etc/patch.cfg
-* /etc/patch.cfg relative to the Python installation site USER_BASE
-* ~/.patch.cfg
-* ./patch.cfg
+* '/etc/patch.cfg'
+* '/etc/patch.cfg' relative to the Python installation site 'USER_BASE'
+* '~/.patch.cfg'
+* './patch.cfg'
 
-These configuration files specify which repositories to search, which are
-considered clones of the upstream "mainline" repository, the user's name, and
-the user's email address.
+These configuration files specify which repositories to search,
+which are considered clones of the upstream 'mainline' repository,
+the user's name, and the user's email address.
 
 FORMAT
 ------
+Python's 'ConfigParser' uses the 'INI' format.
 
-Python's ConfigParser uses the 'INI' format.
-
-There are two sections:
+There are two sections, 'repositories', and 'contact':
 
 * [repositories]
 ** search:
@@ -47,7 +46,6 @@ A space separated list of email addresses used to commit or send patches upstrea
 
 EXAMPLE
 -------
-
  [repositories]
  search:
    .
@@ -59,10 +57,11 @@ EXAMPLE
 
 AVAILABILITY
 ------------
-*patchtools.cfg* is part of Patchtools.
-Please refer to the GitHub repository at https://github.com/jeffmahoney/jpt for more information.
+*patchtools.cfg* is part of patchtools.
+Please refer to the GitHub repository
+at https://github.com/opensuse/patchtools for more information.
 
 SEE ALSO
 --------
-`exportpatch`(1)
-`fixpatch`(1)
+exportpatch(1),
+fixpatch(1)


### PR DESCRIPTION
The man pages were slightly out of date, with respect to repository names, and for exact descriptions of some options.

Some of the changes were purely cosmetic, i.e. changing how the options are listed, to better match regular system man pages.