### PR TITLE
Fix patchops stable tag non-matching

### DIFF
--- a/patchtools/patchops.py
+++ b/patchtools/patchops.py
@@ -21,7 +21,7 @@ def key_version(tag):
 
     # We purposely ignore x.y.z tags since those are from -stable and
     # will never be used in a mainline tag.
-    m = re.match(r"v(\d+)\.(\d+)(-rc(\d+)|)", tag)
+    m = re.fullmatch(r"v(\d+)\.(\d+)(-rc(\d+)|)", tag)
     if m:
         major = int(m.group(1))
         minor = int(m.group(2))


### PR DESCRIPTION
The code says:
```
  # We purposely ignore x.y.z tags since those are from -stable and
  # will never be used in a mainline tag.
```
But uses:
```
  re.match(r"v(\d+)\.(\d+)(-rc(\d+)|)")
```

python's `re.match` is documented as:
>   If zero or more characters at the beginning of string match this regular expression, return a corresponding Match

Use `re.fullmatch()` instead.

Due to this bug, I was missing `Patch-mainline` in the generated patches as I have stable trees in my linux tree.

Now I see proper:
```
  Patch-mainline: v6.20-rc1
```

(Despite there will be no 6.20, but 7.0 :P.)