### PR TITLE
patch.py: Export patches in utf-8

### DIFF
--- a/patchtools/patch.py
+++ b/patchtools/patch.py
@@ -8,7 +8,7 @@ from patchtools import config, PatchException
 import re
 import os
 import os.path
-import email.parser
+import email.parser, email.policy
 import urllib.request, urllib.parse, urllib.error
 from urllib.parse import urlparse
 import string
@@ -137,7 +137,8 @@ class Patch:
             self.message.add_header('Patch-mainline', ' '.join(tag))
 
     def from_email(self, msg):
-        p = email.parser.Parser()
+        pol = email.policy.default.clone(utf8=True)
+        p = email.parser.Parser(policy=pol)
         self.message = p.parsestr(msg)
 
         if 'Git-commit' in self.message:

--- a/patchtools/patchops.py
+++ b/patchtools/patchops.py
@@ -96,7 +96,7 @@ def confirm_commit(commit, repo):
     return True
 
 def canonicalize_commit(commit, repo):
-    return run_command(f"cd {repo} ; git show -s {commit}^{{}} --pretty=%H")
+    return run_command(f"cd {repo} ; git show -s {commit}^{{}} --pretty=%H").strip()
 
 def get_commit(commit, repo, force=False):
     command = f"cd {repo}; git diff-tree --no-renames --pretty=email -r -p --cc --stat {commit}"

--- a/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.excluded_first_and_last
+++ b/test/data/scsi-libsas-Add-rollback-handling-when-an-error-occurs.excluded_first_and_last
@@ -1,8 +1,7 @@
 From: Chaohai Chen <wdhh6@aliyun.com>
 Date: Sat, 6 Dec 2025 14:06:16 +0800
 Subject: scsi: libsas: Add rollback handling when an error occurs
-Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41
- (partial)
+Git-commit: 362432e9b9aefb914ab7d9f86c9fc384a6620c41 (partial)
 Patch-mainline: v6.19-rc1
 Patch-filtered: !drivers/scsi/libsas/sas_init.c !drivers/scsi/libsas/sas_phy.c
 

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.extracted
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.extracted
@@ -1,4 +1,4 @@
-From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+From: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
 Date: Tue, 11 Mar 2025 13:25:16 +0200
 Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
 MIME-Version: 1.0

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.known_good
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.known_good
@@ -1,4 +1,4 @@
-From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+From: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
 Date: Tue, 11 Mar 2025 13:25:16 +0200
 Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
 MIME-Version: 1.0

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.signed_off_by
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.signed_off_by
@@ -1,4 +1,4 @@
-From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+From: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
 Date: Tue, 11 Mar 2025 13:25:16 +0200
 Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
 MIME-Version: 1.0

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference
@@ -1,4 +1,4 @@
-From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+From: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
 Date: Tue, 11 Mar 2025 13:25:16 +0200
 Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
 MIME-Version: 1.0

--- a/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference_twice
+++ b/test/data/scsi-st-Tighten-the-page-format-heuristics-with-MODE-SELECT.some_reference_twice
@@ -1,4 +1,4 @@
-From: =?utf-8?q?Kai_M=C3=A4kisara_=3CKai=2EMakisara=40kolumbus=2Efi=3E?=
+From: Kai Mäkisara <Kai.Makisara@kolumbus.fi>
 Date: Tue, 11 Mar 2025 13:25:16 +0200
 Subject: scsi: st: Tighten the page format heuristics with MODE SELECT
 MIME-Version: 1.0


### PR DESCRIPTION
exportpatch e265b330b93e3a3f9ff5256451d4f09b5f89b239

before:
  From: =?utf-8?b?TWlja2HDq2wgU2FsYcO8biA8bWljQGRpZ2lrb2QubmV0Pg==?=
  Subject: =?utf-8?q?mailmap=3A_Add_entry_for_Micka=C3=ABl_Sala=C3=BCn?=
  Git-commit: e265b330b93e3a3f9ff5256451d4f09b5f89b239

after:
  From: Mickaël Salaün <mic@digikod.net>
  Subject: mailmap: Add entry for Mickaël Salaün
  Git-commit: =?utf-8?q?e265b330b93e3a3f9ff5256451d4f09b5f89b239=0A?=

Note that policy encodes EOL in Git-commit, therefore strip it (so that Git-commmit: remains non-encoded).