### PR TITLE
patchops: Fix mainline commits search

### DIFF
--- a/patchtools/patchops.py
+++ b/patchtools/patchops.py
@@ -35,7 +35,7 @@ class LocalCommitException(PatchException):
     pass
 
 def get_tag(commit, repo):
-    command = f"(cd {repo};git name-rev --refs=refs/tags/v* {commit})"
+    command = f"(cd {repo};git name-rev --refs=refs/tags/v[0-9]* {commit})"
     tag = run_command(command)
     if tag == "":
         return None


### PR DESCRIPTION
When searching in repo with upstream vfs/vfs tree, tags like vfs-6.18-rc2.fixes would match first and that results in generating Patch-mainline: tag which isn't actually a mainline tag.