### PR TITLE
Detect and transform patches from stable tree

### DIFF
--- a/doc/exportpatch.asciidoc
+++ b/doc/exportpatch.asciidoc
@@ -17,7 +17,9 @@ the SUSE kernel-source repository.
 
 It is a requirement that each 'commit' is contained in the git remote repository
 as well as the local repository, though this can be overridden using the '-f'
-option.
+option. The 'commit' can be from a stable tree, in which case, *exportpatch*
+will attempt to transform the patch to mainline. This can be overridden by
+'-T' option.
 
 The behavior of *exportpatch* is controlled by the options below and the
 *patchtools.cfg(5)* configuration files. If no configuration files are
@@ -152,6 +154,13 @@ tags that contain the paths excluded.
 *-S*, *--signed-off-by*::
 By default, every patch exported has the user's 'Acked-by' tag added to it.
 This option uses the 'Signed-off-by' tag instead of 'Acked-by'.
+
+*-T*, *--skip-stable*::
+By default, if the commit is from the stable branch, it would replace
+'Patch-mainline' and 'Git-commit' tag from the commit's body. This option
+disables the check for stable tree and processes it as if it was a mainline
+patch.
+
 
 EXIT STATUS
 -----------

--- a/patchtools/exportpatch.py
+++ b/patchtools/exportpatch.py
@@ -23,7 +23,7 @@ DIR="."
 def export_patch(commit, options, prefix, suffix):
     """Export a single commit/patch. Return 0 for success, else 1."""
     try:
-        p = Patch(commit, debug=options.debug, force=options.force)
+        p = Patch(commit, debug=options.debug, force=options.force, stable=not options.skip_stable)
     except PatchException as e:
         print(e, file=sys.stderr)
         return 1
@@ -43,6 +43,7 @@ def export_patch(commit, options, prefix, suffix):
                 print("Commit %s is now empty. Skipping." % commit, file=sys.stderr)
                 return 0
         p.add_signature(options.signed_off_by)
+        p.stable_to_upstream()
         if options.write:
             fn = p.get_pathname(options.dir, prefix, suffix)
             if os.path.exists(fn) and not options.force:
@@ -101,6 +102,8 @@ def main():
     parser.add_option("-S", "--signed-off-by", action="store_true",
                       default=False,
                       help="Use Signed-off-by instead of Acked-by")
+    parser.add_option("-T", "--skip-stable", action="store_true",
+                     help="do not use heuristics to determine if the patch is from a stable branch", default=False)
 
     try:
         (options, args) = parser.parse_args()

--- a/patchtools/patch.py
+++ b/patchtools/patch.py
@@ -28,7 +28,7 @@ class EmptyCommitException(PatchException):
     pass
 
 class Patch:
-    def __init__(self, commit=None, repo=None, debug=False, force=False):
+    def __init__(self, commit=None, repo=None, debug=False, force=False, stable=True):
         self.commit = commit
         self.repo = repo
         self.debug = debug
@@ -38,6 +38,7 @@ class Patch:
         self.repo_list = config.get_repos()
         self.mainline_repo_list = config.get_mainline_repos()
         self.in_mainline = False
+        self.stable = stable
         if repo in self.mainline_repo_list:
             self.in_mainline = True
         if self.debug:
@@ -474,6 +475,26 @@ class Patch:
 
         if is_empty:
             raise EmptyCommitException("commit is empty")
+
+    def stable_to_upstream(self):
+        if not self.stable:
+          return
+        text = self.message.get_payload().splitlines()
+        first_line = text[0]
+        if not "upstream" in first_line.casefold():
+          return
+        commit = ""
+        for word in first_line.split(' '):
+          if len(word) == 40 and all(c in string.hexdigits for c in word):
+              commit = word
+              break
+        if commit:
+          if self.debug:
+            print("Transforming stable commit to mainline ", word)
+          self.message.replace_header('Git-commit', commit)
+          self.message.replace_header('Patch-mainline', patchops.get_tag(commit, self.repo))
+	  # Delete the first two lines
+          self.message.set_payload('\n'.join(map(str, text[2:])))
 
     def update_refs(self, refs):
         if not 'References' in self.message:


### PR DESCRIPTION
While backporting CVE fixes, it is easier to use the patches from the stable branch. However, they need to be changed to get to the patch standards. For example, the Patch-mainline and Git-commit tag need to be changed.

This PR detects if the patch is from a stable tree and if yes, tries to find the upstream commit in the first line. If found, it changes the Git-commit and Patch-mainline tag and finally deletes the first line.

Use -T to disable stable detection/transformation.